### PR TITLE
compositor: fix output positioning

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -1062,9 +1062,8 @@ impl Fht {
                 .filter(|&target_pos| {
                     let target_geo = Rectangle::new(target_pos, size);
                     // if we have overlap, this position is not good, simple as that.
-                    if let Some(overlap) = self
-                        .space
-                        .outputs()
+                    if let Some(overlap) = arranged_outputs
+                        .iter()
                         .map(OutputExt::geometry)
                         .find(|geo| geo.overlaps(target_geo))
                     {


### PR DESCRIPTION
fixes output positioning not working properly

before if i had specified:

[outputs]
"HDMI-A-1" = { transform = "90", position = [0, 0] }
"DP-1" = { position = [1080, 0] }

then if i would move my cursor to the left of DP-1 to try to go into HDMI-A-1, it would not work, even if transform was not specified

It would make me go right to go into HDMI-A-1 which is incorrect