### PR TITLE
workspace: don't exit fullscreen when setting active tile

### DIFF
--- a/src/space/workspace.rs
+++ b/src/space/workspace.rs
@@ -388,7 +388,6 @@ impl Workspace {
     ///
     /// This will get clamped to a valid value when [`Workspace::refresh`] is called.
     pub fn set_active_tile_idx(&mut self, idx: usize) {
-        self.remove_current_fullscreen();
         self.active_tile_idx = Some(idx);
     }
 


### PR DESCRIPTION
this line is problematic:

If you have a window fullscreened on monitor 1, then if you change focus to monitor 2, monitor 1 would be in a floating state which is the size of a little bit more of your monitor UNTIL you picked the window up then it would return to the tiled state.

This is completely wrong because:

A: Each monitor should be completely separate from eachother, as seen with workspaces, doing actions on one monitor should not affect the other, so if i change focus from monitor 1 to monitor 2, monitor 1's windows should never be affected by what is happening on monitor 2
B: If we unfullscreen the window on monitor 1 when the user switches to monitor 2 then we should not put it in a "psuedo-floating state", which is a bug, but big point made in "A"

Removing fullscreen still works for switching window focus, etc. It's just this line is very problematic, and rather annoying