### PR TITLE
Rework `SwapTileGrab` to work across different outputs

### DIFF
--- a/src/handlers/compositor.rs
+++ b/src/handlers/compositor.rs
@@ -18,7 +18,6 @@ use smithay::wayland::dmabuf::get_dmabuf;
 use smithay::wayland::seat::WaylandFocus;
 use smithay::wayland::shell::xdg::{
     SurfaceCachedState, XdgPopupSurfaceData, XdgToplevelSurfaceData,
-    XdgToplevelSurfaceRoleAttributes,
 };
 
 use crate::state::{Fht, ResolvedWindowRules, State, UnmappedWindow};

--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -104,7 +104,11 @@ impl XdgShellHandler for State {
         };
 
         if let Some(window) = self.fht.space.find_window(surface.wl_surface()) {
-            if self.fht.space.start_interactive_swap(&window) {
+            if self
+                .fht
+                .space
+                .start_interactive_swap(&window, start_data.location.to_i32_round())
+            {
                 let grab = SwapTileGrab { window, start_data };
                 pointer.set_grab(self, grab, serial, Focus::Clear);
                 self.fht

--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -3,7 +3,7 @@ use smithay::desktop::{
     find_popup_root_surface, get_popup_toplevel_coords, layer_map_for_output, PopupKeyboardGrab,
     PopupKind, PopupPointerGrab, PopupUngrabStrategy, WindowSurfaceType,
 };
-use smithay::input::pointer::Focus;
+use smithay::input::pointer::{CursorIcon, CursorImageStatus, Focus};
 use smithay::input::Seat;
 use smithay::output::Output;
 use smithay::reexports::wayland_protocols::xdg::shell::server::xdg_toplevel::{
@@ -103,26 +103,14 @@ impl XdgShellHandler for State {
             return;
         };
 
-        let mut output = None;
-        if let Some((window, workspace)) = self
-            .fht
-            .space
-            .find_window_and_workspace_mut(surface.wl_surface())
-        {
-            // if workspace.start_interactive_swap(&window) {
-            //     let ws_output = workspace.output().clone();
-            //     output = Some(ws_output.clone()); // augh, the borrow checker
-            //     let grab = SwapTileGrab {
-            //         window,
-            //         output: ws_output,
-            //         start_data,
-            //     };
-            //     pointer.set_grab(self, grab, serial, Focus::Clear);
-            // }
-        }
-
-        if let Some(ref output) = output {
-            self.fht.queue_redraw(output);
+        if let Some(window) = self.fht.space.find_window(surface.wl_surface()) {
+            if self.fht.space.start_interactive_swap(&window) {
+                let grab = SwapTileGrab { window, start_data };
+                pointer.set_grab(self, grab, serial, Focus::Clear);
+                self.fht
+                    .cursor_theme_manager
+                    .set_image_status(CursorImageStatus::Named(CursorIcon::Grabbing));
+            }
         }
     }
 

--- a/src/handlers/xdg_shell.rs
+++ b/src/handlers/xdg_shell.rs
@@ -109,16 +109,16 @@ impl XdgShellHandler for State {
             .space
             .find_window_and_workspace_mut(surface.wl_surface())
         {
-            if workspace.start_interactive_swap(&window) {
-                let ws_output = workspace.output().clone();
-                output = Some(ws_output.clone()); // augh, the borrow checker
-                let grab = SwapTileGrab {
-                    window,
-                    output: ws_output,
-                    start_data,
-                };
-                pointer.set_grab(self, grab, serial, Focus::Clear);
-            }
+            // if workspace.start_interactive_swap(&window) {
+            //     let ws_output = workspace.output().clone();
+            //     output = Some(ws_output.clone()); // augh, the borrow checker
+            //     let grab = SwapTileGrab {
+            //         window,
+            //         output: ws_output,
+            //         start_data,
+            //     };
+            //     pointer.set_grab(self, grab, serial, Focus::Clear);
+            // }
         }
 
         if let Some(ref output) = output {

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -6,7 +6,6 @@ use smithay::desktop::WindowSurfaceType;
 use smithay::input::pointer::{self, CursorIcon, CursorImageStatus, Focus};
 use smithay::reexports::calloop::timer::{TimeoutAction, Timer};
 use smithay::utils::{Point, Rectangle, Serial};
-use smithay::wayland::seat::WaylandFocus;
 
 use super::swap_tile_grab::SwapTileGrab;
 use crate::focus_target::PointerFocusTarget;
@@ -508,12 +507,6 @@ impl State {
                 if let Some((PointerFocusTarget::Window(window), _)) =
                     self.fht.focus_target_under(pointer_loc)
                 {
-                    let output = self
-                        .fht
-                        .space
-                        .output_for_surface(&*window.wl_surface().unwrap())
-                        .unwrap()
-                        .clone();
                     let pointer = self.fht.pointer.clone();
                     let start_data = pointer::GrabStartData {
                         focus: None,
@@ -522,11 +515,7 @@ impl State {
                     };
 
                     if self.fht.space.start_interactive_swap(&window) {
-                        let grab = SwapTileGrab {
-                            window,
-                            output,
-                            start_data,
-                        };
+                        let grab = SwapTileGrab { window, start_data };
                         pointer.set_grab(self, grab, serial, Focus::Clear);
                         self.fht
                             .cursor_theme_manager

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -514,7 +514,11 @@ impl State {
                         location: pointer_loc,
                     };
 
-                    if self.fht.space.start_interactive_swap(&window) {
+                    if self
+                        .fht
+                        .space
+                        .start_interactive_swap(&window, pointer_loc.to_i32_round())
+                    {
                         let grab = SwapTileGrab { window, start_data };
                         pointer.set_grab(self, grab, serial, Focus::Clear);
                         self.fht

--- a/src/input/swap_tile_grab.rs
+++ b/src/input/swap_tile_grab.rs
@@ -30,11 +30,10 @@ impl PointerGrab<State> for SwapTileGrab {
         // No focus while motion is active
         handle.motion(data, None, event);
 
-        let delta = (event.location - self.start_data.location).to_i32_round();
         if data
             .fht
             .space
-            .handle_interactive_swap_motion(&self.window, delta)
+            .handle_interactive_swap_motion(&self.window, event.location.to_i32_round())
         {
             return;
         }

--- a/src/input/swap_tile_grab.rs
+++ b/src/input/swap_tile_grab.rs
@@ -30,19 +30,8 @@ impl PointerGrab<State> for SwapTileGrab {
         _focus: Option<(PointerFocusTarget, Point<f64, Logical>)>,
         event: &MotionEvent,
     ) {
-        // Clamp the event's position so that we do not go outside the output.
-        let (pos_x, pos_y) = event.location.into();
-        let geometry = self.output.geometry().to_f64();
-        // Give is -/+5.0 to avoid the pointer being between two outputs.
-        let clamped_x = pos_x.clamp(geometry.loc.x + 5.0, geometry.loc.x + geometry.size.w - 5.0);
-        let clamped_y = pos_y.clamp(geometry.loc.y + 5.0, geometry.loc.y + geometry.size.h - 5.0);
-        let event = MotionEvent {
-            location: (clamped_x, clamped_y).into(),
-            ..*event
-        };
-
         // No focus while motion is active
-        handle.motion(data, None, &event);
+        handle.motion(data, None, event);
 
         let delta = (event.location - self.start_data.location).to_i32_round();
         if data

--- a/src/input/swap_tile_grab.rs
+++ b/src/input/swap_tile_grab.rs
@@ -1,8 +1,8 @@
 use smithay::input::pointer::{
-    AxisFrame, ButtonEvent, GestureHoldBeginEvent, GestureHoldEndEvent, GesturePinchBeginEvent,
-    GesturePinchEndEvent, GesturePinchUpdateEvent, GestureSwipeBeginEvent, GestureSwipeEndEvent,
-    GestureSwipeUpdateEvent, GrabStartData, MotionEvent, PointerGrab, PointerInnerHandle,
-    RelativeMotionEvent,
+    AxisFrame, ButtonEvent, CursorIcon, CursorImageStatus, GestureHoldBeginEvent,
+    GestureHoldEndEvent, GesturePinchBeginEvent, GesturePinchEndEvent, GesturePinchUpdateEvent,
+    GestureSwipeBeginEvent, GestureSwipeEndEvent, GestureSwipeUpdateEvent, GrabStartData,
+    MotionEvent, PointerGrab, PointerInnerHandle, RelativeMotionEvent,
 };
 use smithay::output::Output;
 use smithay::utils::{Logical, Point};
@@ -159,5 +159,10 @@ impl PointerGrab<State> for SwapTileGrab {
         &self.start_data
     }
 
-    fn unset(&mut self, _: &mut State) {}
+    fn unset(&mut self, state: &mut State) {
+        state
+            .fht
+            .cursor_theme_manager
+            .set_image_status(CursorImageStatus::Named(CursorIcon::Default));
+    }
 }

--- a/src/input/swap_tile_grab.rs
+++ b/src/input/swap_tile_grab.rs
@@ -4,11 +4,9 @@ use smithay::input::pointer::{
     GestureSwipeBeginEvent, GestureSwipeEndEvent, GestureSwipeUpdateEvent, GrabStartData,
     MotionEvent, PointerGrab, PointerInnerHandle, RelativeMotionEvent,
 };
-use smithay::output::Output;
 use smithay::utils::{Logical, Point};
 
 use crate::focus_target::PointerFocusTarget;
-use crate::output::OutputExt;
 use crate::state::State;
 use crate::window::Window;
 
@@ -18,7 +16,6 @@ use crate::window::Window;
 // process is only between tiled windows.
 pub struct SwapTileGrab {
     pub window: Window,
-    pub output: Output,
     pub start_data: GrabStartData<State>,
 }
 

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -25,7 +25,6 @@ use smithay::backend::allocator::dmabuf::Dmabuf;
 use smithay::backend::allocator::{Buffer as _, Fourcc};
 use smithay::backend::renderer::damage::OutputDamageTracker;
 use smithay::backend::renderer::element::solid::SolidColorRenderElement;
-use smithay::backend::renderer::element::utils::RelocateRenderElement;
 use smithay::backend::renderer::element::{AsRenderElements, RenderElement};
 use smithay::backend::renderer::gles::{
     GlesError, GlesMapping, GlesTexture, Uniform, UniformValue,

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -25,6 +25,7 @@ use smithay::backend::allocator::dmabuf::Dmabuf;
 use smithay::backend::allocator::{Buffer as _, Fourcc};
 use smithay::backend::renderer::damage::OutputDamageTracker;
 use smithay::backend::renderer::element::solid::SolidColorRenderElement;
+use smithay::backend::renderer::element::utils::RelocateRenderElement;
 use smithay::backend::renderer::element::{AsRenderElements, RenderElement};
 use smithay::backend::renderer::gles::{
     GlesError, GlesMapping, GlesTexture, Uniform, UniformValue,
@@ -55,7 +56,7 @@ use crate::cursor::CursorRenderElement;
 use crate::handlers::session_lock::SessionLockRenderElement;
 use crate::layer::{layer_elements, LayerShellRenderElement};
 use crate::protocols::screencopy::{ScreencopyBuffer, ScreencopyFrame};
-use crate::space::{MonitorRenderElement, MonitorRenderResult};
+use crate::space::{MonitorRenderElement, MonitorRenderResult, TileRenderElement};
 use crate::state::Fht;
 use crate::utils::get_monotonic_time;
 
@@ -64,6 +65,7 @@ crate::fht_render_elements! {
         Cursor = CursorRenderElement<R>,
         ConfigUi = ConfigUiRenderElement,
         Monitor = MonitorRenderElement<R>,
+        Tile = TileRenderElement<R>, // Needed for interactive swap
         LayerShell = LayerShellRenderElement<R>,
         SessionLock = SessionLockRenderElement<R>,
         Debug = DebugRenderElement,
@@ -186,6 +188,11 @@ impl Fht {
         // Overlay layer shells are drawn above everything else, including fullscreen windows
         let overlay_elements = layer_elements(renderer, output, Layer::Overlay, &self.config);
         rv.elements.extend(overlay_elements);
+
+        // Interactive move tile goes above everything else
+        let interactive_move_elements = self.space.render_interactive_swap(renderer, output, scale);
+        rv.elements
+            .extend(interactive_move_elements.into_iter().map(Into::into));
 
         // Top layer shells sit between the normal windows and fullscreen windows.
         //

--- a/src/space/mod.rs
+++ b/src/space/mod.rs
@@ -780,7 +780,9 @@ impl Space {
                 if let Some((idx, mut tile)) = workspace.start_interactive_swap(window) {
                     // Make the tile slightly smaller, just for aesthetic purposes and give a visual
                     // clue that we grabbed it and is not in a swap state.
-                    tile.set_size(tile.size().to_f64().upscale(0.8).to_i32_round(), true);
+                    if tile.window().tiled() {
+                        tile.set_size(tile.size().to_f64().upscale(0.8).to_i32_round(), true);
+                    }
 
                     let output = workspace.output().clone();
                     let mut initial_geometry = tile.geometry();

--- a/src/space/mod.rs
+++ b/src/space/mod.rs
@@ -895,7 +895,7 @@ impl Space {
 
         interactive_swap
             .tile
-            .render_at(
+            .render_for_interactive_grab(
                 renderer,
                 interactive_swap.current_location - output.current_location(),
                 scale,

--- a/src/space/mod.rs
+++ b/src/space/mod.rs
@@ -832,9 +832,13 @@ impl Space {
         window: &Window,
         cursor_position: Point<f64, Logical>,
     ) {
-        let Some(interactive_swap) = self.interactive_swap.take() else {
+        let Some(mut interactive_swap) = self.interactive_swap.take() else {
             return;
         };
+
+        if interactive_swap.tile.window() != window {
+            return;
+        }
 
         let monitor_under = self
             .monitors
@@ -845,6 +849,12 @@ impl Space {
                     .contains(cursor_position.to_i32_round())
             })
             .expect("Cursor position out of space!");
+        // Move the tile to the correct position relative to the output so that animation doesn't
+        // break, since handle_interactive_swap_motion sets the absolute position
+        interactive_swap.tile.set_location(
+            interactive_swap.current_location - monitor_under.output().current_location(),
+            false,
+        );
         monitor_under
             .active_workspace_mut()
             .insert_tile_with_cursor_position(

--- a/src/space/tile.rs
+++ b/src/space/tile.rs
@@ -605,7 +605,7 @@ impl Tile {
         &self,
         renderer: &mut R,
         scale: i32,
-        alpha: f32,
+        mut alpha: f32,
         output: &Output,
         render_offset: Point<i32, Logical>,
         active: bool,
@@ -640,6 +640,9 @@ impl Tile {
             let rec = elements.iter().fold(Rectangle::default(), |acc, e| {
                 acc.merge(e.geometry(fractional_scale))
             });
+            // Only include alpha now to render the inner window with full alpha.
+            // The texture will lower the opacity of that, but for the rest we gotta account for it.
+            alpha *= (progress as f32).clamp(0., 1.);
 
             tile_geometry = {
                 let mut geo = render_geo;
@@ -676,7 +679,7 @@ impl Tile {
                     texture,
                     scale,
                     Transform::Normal,
-                    Some(alpha * progress.clamp(0., 1.) as f32),
+                    Some(alpha),
                     None,
                     None,
                     None,
@@ -823,7 +826,7 @@ impl Tile {
         renderer: &mut R,
         visual_location: Point<i32, Logical>,
         scale: i32,
-        alpha: f32,
+        mut alpha: f32,
         output: &Output,
         render_offset: Point<i32, Logical>,
         active: bool,
@@ -858,6 +861,9 @@ impl Tile {
             let rec = elements.iter().fold(Rectangle::default(), |acc, e| {
                 acc.merge(e.geometry(fractional_scale))
             });
+            // Only include alpha now to render the inner window with full alpha.
+            // The texture will lower the opacity of that, but for the rest we gotta account for it.
+            alpha *= (progress as f32).clamp(0., 1.);
 
             tile_geometry = {
                 let mut geo = render_geo;

--- a/src/space/tile.rs
+++ b/src/space/tile.rs
@@ -407,27 +407,14 @@ impl Tile {
     }
 
     /// Take a snapshot for running a [`ClosingTile`].
-    pub fn prepare_close_animation_if_needed(
-        &mut self,
-        output: &Output,
-        renderer: &mut GlowRenderer,
-        scale: i32,
-    ) {
+    pub fn prepare_close_animation_if_needed(&mut self, renderer: &mut GlowRenderer, scale: i32) {
         if self.close_animation_snapshot.is_some() {
             return;
         }
 
         // FIXME: Blur with closing tiles is kinda wonky, but you shouldn't notice it unless
         // you have a *very* slow closing animation
-        let elements = self.render_inner(
-            renderer,
-            (0, 0).into(),
-            scale,
-            1.0,
-            output,
-            (0, 0).into(),
-            false,
-        );
+        let elements = self.render_inner(renderer, (0, 0).into(), scale, 1.0);
         self.close_animation_snapshot = Some(elements);
     }
 
@@ -450,14 +437,10 @@ impl Tile {
         location: Point<i32, Logical>,
         scale: i32,
         alpha: f32,
-        output: &Output,
-        render_offset: Point<i32, Logical>,
-        active: bool,
     ) -> Vec<TileRenderElement<R>> {
         crate::profile_function!();
         let mut elements = vec![];
         let rules = self.window.rules();
-        let is_floating = !self.window.tiled();
         let is_fullscreen = self.window.fullscreen();
 
         let alpha = if is_fullscreen {
@@ -467,14 +450,6 @@ impl Tile {
         };
 
         let border = self.config.border.with_overrides(&rules.border);
-        let shadow = self
-            .config
-            .shadow
-            .map(|cfg| cfg.with_overrides(&rules.shadow));
-        let (blur, blur_optimized) = (
-            self.config.blur.with_overrides(&rules.blur),
-            rules.blur.optimized,
-        );
         let (border_thickness, border_radius) = if is_fullscreen {
             (0, 0.0)
         } else {
@@ -484,7 +459,6 @@ impl Tile {
         drop(rules); // Avoid deadlock :skull:
 
         let has_size_animation = self.size_animation.is_some();
-        let has_opening_animation = self.opening_animation.is_some();
         let tile_geometry = Rectangle::new(location, self.visual_size());
         let window_geometry = Rectangle::new(
             location + Point::<i32, Logical>::from((border_thickness, border_thickness)),
@@ -621,99 +595,6 @@ impl Tile {
             elements.extend(window_elements);
         };
 
-        if !blur.disabled() && self.has_transparent_region() {
-            // Optimized blur uses a pre-blurred texture containing background and bottom
-            // layer shells. True blur (non-optimized) blurs in real time whatever is behind the
-            // window.
-            //
-            // When a window is tiled, it will most likely only display the background, IE there
-            // are no windows behind it, so we win quit a lot of performance when enabling optimized
-            // blur here since tiled windows are *huge*
-            //
-            // Floating windows on the other hand might have other windows below it, so they don't
-            // use optimized. They are also (in comparaison) relatively small, so its even better
-            let optimized = blur_optimized.unwrap_or_else(|| {
-                let mut optimized = !is_floating;
-                if has_opening_animation {
-                    // One exception is made for opening animations. Since we pre-render the window
-                    // inside a texture, there's nothing for us to sample from, so we must use
-                    // optimized in order to get a blur effect going on.
-                    optimized = true;
-                }
-
-                optimized
-            });
-
-            // Since tile_geometry and window_geometry are dependent on what we are rendering for
-            // (opening animation, size animation) we use data gathered from self instead
-            //
-            // render_offset is from the workspace, to account for switching animations
-            let sample_area = Rectangle::new(
-                self.visual_location() + self.window_loc() + render_offset,
-                window_geometry.size,
-            );
-
-            let blur_element = BlurElement::new(
-                renderer,
-                output,
-                sample_area,
-                window_geometry.loc.to_physical(scale),
-                border_radius,
-                optimized,
-                scale,
-                alpha,
-                blur,
-            );
-            elements.push(blur_element.into());
-        }
-
-        if border_thickness != 0 {
-            elements.push(
-                super::decorations::draw_border(
-                    renderer,
-                    scale,
-                    alpha,
-                    tile_geometry,
-                    border_thickness as f64,
-                    border_radius as f64,
-                    if active {
-                        border.focused_color
-                    } else {
-                        border.normal_color
-                    },
-                )
-                .into(),
-            );
-        }
-
-        if let Some(shadow_config) = &shadow {
-            let should_draw = if shadow_config.disable {
-                false
-            } else {
-                match shadow_config.floating_only {
-                    true => is_floating,
-                    // NOTE: For now we draw shadows by default.
-                    // Maybe reconsider this?
-                    false => true,
-                }
-            };
-
-            if !is_fullscreen && shadow_config.color[3] > 0.0 && should_draw {
-                elements.push(
-                    super::decorations::draw_shadow(
-                        renderer,
-                        alpha,
-                        scale,
-                        window_geometry,
-                        shadow_config.sigma,
-                        border_radius,
-                        shadow_config.color,
-                    )
-                    .into(),
-                );
-            }
-        }
-
         elements
     }
 
@@ -734,39 +615,40 @@ impl Tile {
         let mut opening_element = None;
         let mut normal_elements = vec![];
 
+        // Rendering tile goes through the following phases.
+        //
+        // 1. Tile::render_inner renders the tile's window and popups, and applies the resize the
+        //    current size_animation if any to the main window surface(s) and rounded corners
+        //
+        // 2. If there's a resize animation ongoing, we draw the generated render elements into a
+        //    texture and draw it with a custom size and rescale it.
+        //
+        // 3. We draw additional decorations: blur, shadow, border, etc.
+        //
+        // FIXME: Redundant calculations here and and in render_inner, but compiler should optimize
+        // them away (hopefully)? Either way they are not too expensive.
+
+        let tile_geometry;
+
         if let Some(animation) = self.opening_animation.as_ref() {
-            let render_geo = self.visual_geometry().to_physical_precise_round(scale);
+            let render_geo = self.visual_geometry();
             let progress = *animation.value();
+            let opening_animation_scale = opening_animation_progress_to_scale(progress);
 
             let glow_renderer = renderer.glow_renderer_mut();
-
-            // Account for the shadow else it will get cut short.
-            let mut shadow_offset = Point::default();
-            let rules = self.window.rules();
-            if let Some(shadow) = self
-                .config
-                .shadow
-                .map(|shadow| shadow.with_overrides(&rules.shadow))
-            {
-                let scaled_sigma = (shadow.sigma / scale as f32).round() as i32;
-                shadow_offset = Point::from((scaled_sigma, scaled_sigma));
-            }
-            drop(rules);
-
-            // NOTE: We use the border thickness as the location to actually include it with the
-            // render elements, otherwise it would be clipped out of the tile.
-            let elements = self.render_inner(
-                glow_renderer,
-                shadow_offset,
-                scale,
-                alpha,
-                output,
-                render_offset,
-                active,
-            );
+            let elements = self.render_inner(glow_renderer, Point::default(), scale, alpha);
             let rec = elements.iter().fold(Rectangle::default(), |acc, e| {
                 acc.merge(e.geometry(fractional_scale))
             });
+
+            tile_geometry = {
+                let mut geo = render_geo;
+                let center = geo.center();
+                geo.loc -= center;
+                geo = geo.to_f64().upscale(opening_animation_scale).to_i32_round();
+                geo.loc += center;
+                geo
+            };
 
             opening_element = render_to_texture(
                 glow_renderer,
@@ -790,7 +672,7 @@ impl Tile {
                 let texture: FhtTextureElement = TextureRenderElement::from_static_texture(
                     element_id.clone(),
                     glow_renderer.id(),
-                    render_geo.loc.to_f64() - shadow_offset.to_f64().to_physical(scale as f64),
+                    render_geo.to_physical(scale).loc.to_f64(),
                     texture,
                     scale,
                     Transform::Normal,
@@ -803,38 +685,140 @@ impl Tile {
                 .into();
                 self.window.set_offscreen_element_id(Some(element_id));
 
-                let origin = render_geo.center();
-                let rescale = RescaleRenderElement::from_element(
-                    texture,
-                    origin,
-                    opening_animation_progress_to_scale(progress),
-                );
+                let origin = render_geo.to_physical(scale).center();
+                let rescale =
+                    RescaleRenderElement::from_element(texture, origin, opening_animation_scale);
 
                 TileRenderElement::<R>::Opening(rescale)
             });
-        };
-
-        if opening_element.is_none() {
+        } else {
             self.window.set_offscreen_element_id(None);
-            normal_elements = self.render_inner(
-                renderer,
-                self.visual_location(),
-                scale,
-                alpha,
-                output,
-                render_offset,
-                active,
-            )
+            tile_geometry = self.visual_geometry();
+            normal_elements = self.render_inner(renderer, self.visual_location(), scale, alpha)
         }
 
-        opening_element.into_iter().chain(normal_elements)
+        let is_fullscreen = self.window.fullscreen();
+        let is_floating = !self.window.tiled();
+        let rules = self.window.rules();
+        let border = self.config.border.with_overrides(&rules.border);
+        let (border_thickness, border_radius) = if is_fullscreen {
+            (0, 0.0)
+        } else {
+            (border.thickness, border.radius)
+        };
+        let (blur, optimized_blur) = (
+            self.config.blur.with_overrides(&rules.blur),
+            rules.blur.optimized,
+        );
+        let shadow = self
+            .config
+            .shadow
+            .as_ref()
+            .map(|shadow| shadow.with_overrides(&rules.shadow));
+
+        drop(rules);
+
+        let window_geometry = Rectangle::new(
+            tile_geometry.loc + Point::<i32, Logical>::from((border_thickness, border_thickness)),
+            tile_geometry.size - Size::from((border_thickness, border_thickness)).upscale(2),
+        );
+
+        let border_element = (border_thickness != 0)
+            .then(|| {
+                super::decorations::draw_border(
+                    renderer,
+                    scale,
+                    alpha,
+                    tile_geometry,
+                    border_thickness as f64,
+                    border_radius as f64,
+                    if active {
+                        border.focused_color
+                    } else {
+                        border.normal_color
+                    },
+                )
+                .into()
+            })
+            .into_iter();
+
+        let blur_element = (!blur.disabled() && self.has_transparent_region())
+            .then(|| {
+                // Optimized blur uses a pre-blurred texture containing background and bottom
+                // layer shells. True blur (non-optimized) blurs in real time whatever is behind the
+                // window.
+                //
+                // When a window is tiled, it will most likely only display the background, IE there
+                // are no windows behind it, so we win quit a lot of performance when enabling
+                // optimized blur here since tiled windows are *huge*
+                //
+                // Floating windows on the other hand might have other windows below it, so they
+                // don't use optimized. They are also (in comparaison) relatively
+                // small, so its even better
+                let optimized = optimized_blur.unwrap_or_else(|| is_floating);
+
+                // render_offset is from the workspace, to account for switching animations
+                let sample_area =
+                    Rectangle::new(window_geometry.loc + render_offset, window_geometry.size);
+
+                BlurElement::new(
+                    renderer,
+                    output,
+                    sample_area,
+                    window_geometry.loc.to_physical(scale),
+                    border_radius,
+                    optimized,
+                    scale,
+                    alpha,
+                    blur,
+                )
+                .into()
+            })
+            .into_iter();
+
+        let shadow_element = shadow
+            .and_then(|shadow| {
+                let should_draw = if shadow.disable {
+                    false
+                } else {
+                    match shadow.floating_only {
+                        true => is_floating,
+                        false => true,
+                    }
+                };
+
+                if !is_fullscreen && shadow.color[3] > 0.0 && should_draw {
+                    Some(
+                        super::decorations::draw_shadow(
+                            renderer,
+                            alpha,
+                            scale,
+                            window_geometry,
+                            shadow.sigma,
+                            border_radius,
+                            shadow.color,
+                        )
+                        .into(),
+                    )
+                } else {
+                    None
+                }
+            })
+            .into_iter();
+
+        opening_element
+            .into_iter()
+            .chain(normal_elements)
+            .chain(border_element)
+            .chain(blur_element)
+            .chain(shadow_element)
     }
 
-    /// Render the elements for this [`Tile`] at a specific visual location.
-    /// The passed in location will be used instead of [`Tile::visual_location`]
+    /// Custom render function used only in the context of rendering a tile when its being grabbed
+    /// and dragged accross different outputs. Only used for the SwapTileGrab.
     ///
-    /// The [`Tile`] uses its `location` to render the elements.
-    pub fn render_at<R: FhtRenderer>(
+    /// You should **NOT** be using this.
+    pub(super) fn render_for_interactive_grab<R: FhtRenderer>(
         &self,
         renderer: &mut R,
         visual_location: Point<i32, Logical>,
@@ -849,40 +833,40 @@ impl Tile {
         let mut opening_element = None;
         let mut normal_elements = vec![];
 
+        // Rendering tile goes through the following phases.
+        //
+        // 1. Tile::render_inner renders the tile's window and popups, and applies the resize the
+        //    current size_animation if any to the main window surface(s) and rounded corners
+        //
+        // 2. If there's a resize animation ongoing, we draw the generated render elements into a
+        //    texture and draw it with a custom size and rescale it.
+        //
+        // 3. We draw additional decorations: blur, shadow, border, etc.
+        //
+        // FIXME: Redundant calculations here and and in render_inner, but compiler should optimize
+        // them away (hopefully)? Either way they are not too expensive.
+
+        let tile_geometry;
+
         if let Some(animation) = self.opening_animation.as_ref() {
-            let render_geo =
-                Rectangle::new(visual_location, self.visual_geometry().size).to_physical(scale);
+            let render_geo = Rectangle::new(visual_location, self.visual_size());
             let progress = *animation.value();
+            let opening_animation_scale = opening_animation_progress_to_scale(progress);
 
             let glow_renderer = renderer.glow_renderer_mut();
-
-            // Account for the shadow else it will get cut short.
-            let mut shadow_offset = Point::default();
-            let rules = self.window.rules();
-            if let Some(shadow) = self
-                .config
-                .shadow
-                .map(|shadow| shadow.with_overrides(&rules.shadow))
-            {
-                let scaled_sigma = (shadow.sigma / scale as f32).round() as i32;
-                shadow_offset = Point::from((scaled_sigma, scaled_sigma));
-            }
-            drop(rules);
-
-            // NOTE: We use the border thickness as the location to actually include it with the
-            // render elements, otherwise it would be clipped out of the tile.
-            let elements = self.render_inner(
-                glow_renderer,
-                shadow_offset,
-                scale,
-                alpha,
-                output,
-                render_offset,
-                active,
-            );
+            let elements = self.render_inner(glow_renderer, Point::default(), scale, alpha);
             let rec = elements.iter().fold(Rectangle::default(), |acc, e| {
                 acc.merge(e.geometry(fractional_scale))
             });
+
+            tile_geometry = {
+                let mut geo = render_geo;
+                let center = geo.center();
+                geo.loc -= center;
+                geo = geo.to_f64().upscale(opening_animation_scale).to_i32_round();
+                geo.loc += center;
+                geo
+            };
 
             opening_element = render_to_texture(
                 glow_renderer,
@@ -906,7 +890,7 @@ impl Tile {
                 let texture: FhtTextureElement = TextureRenderElement::from_static_texture(
                     element_id.clone(),
                     glow_renderer.id(),
-                    render_geo.loc.to_f64() - shadow_offset.to_f64().to_physical(scale as f64),
+                    render_geo.to_physical(scale).loc.to_f64(),
                     texture,
                     scale,
                     Transform::Normal,
@@ -919,31 +903,133 @@ impl Tile {
                 .into();
                 self.window.set_offscreen_element_id(Some(element_id));
 
-                let origin = render_geo.center();
-                let rescale = RescaleRenderElement::from_element(
-                    texture,
-                    origin,
-                    opening_animation_progress_to_scale(progress),
-                );
+                let origin = render_geo.to_physical(scale).center();
+                let rescale =
+                    RescaleRenderElement::from_element(texture, origin, opening_animation_scale);
 
                 TileRenderElement::<R>::Opening(rescale)
             });
-        };
-
-        if opening_element.is_none() {
+        } else {
             self.window.set_offscreen_element_id(None);
-            normal_elements = self.render_inner(
-                renderer,
-                visual_location,
-                scale,
-                alpha,
-                output,
-                render_offset,
-                active,
-            )
+            tile_geometry = Rectangle::new(visual_location, self.visual_size());
+            normal_elements = self.render_inner(renderer, visual_location, scale, alpha)
         }
 
-        opening_element.into_iter().chain(normal_elements)
+        let is_fullscreen = self.window.fullscreen();
+        let is_floating = !self.window.tiled();
+        let rules = self.window.rules();
+        let border = self.config.border.with_overrides(&rules.border);
+        let (border_thickness, border_radius) = if is_fullscreen {
+            (0, 0.0)
+        } else {
+            (border.thickness, border.radius)
+        };
+        let (blur, optimized_blur) = (
+            self.config.blur.with_overrides(&rules.blur),
+            rules.blur.optimized,
+        );
+        let shadow = self
+            .config
+            .shadow
+            .as_ref()
+            .map(|shadow| shadow.with_overrides(&rules.shadow));
+
+        drop(rules);
+
+        let window_geometry = Rectangle::new(
+            tile_geometry.loc + Point::<i32, Logical>::from((border_thickness, border_thickness)),
+            tile_geometry.size - Size::from((border_thickness, border_thickness)).upscale(2),
+        );
+
+        let border_element = (border_thickness != 0)
+            .then(|| {
+                super::decorations::draw_border(
+                    renderer,
+                    scale,
+                    alpha,
+                    tile_geometry,
+                    border_thickness as f64,
+                    border_radius as f64,
+                    if active {
+                        border.focused_color
+                    } else {
+                        border.normal_color
+                    },
+                )
+                .into()
+            })
+            .into_iter();
+
+        let blur_element = (!blur.disabled() && self.has_transparent_region())
+            .then(|| {
+                // Optimized blur uses a pre-blurred texture containing background and bottom
+                // layer shells. True blur (non-optimized) blurs in real time whatever is behind the
+                // window.
+                //
+                // When a window is tiled, it will most likely only display the background, IE there
+                // are no windows behind it, so we win quit a lot of performance when enabling
+                // optimized blur here since tiled windows are *huge*
+                //
+                // Floating windows on the other hand might have other windows below it, so they
+                // don't use optimized. They are also (in comparaison) relatively
+                // small, so its even better
+                let optimized = optimized_blur.unwrap_or_else(|| is_floating);
+
+                // render_offset is from the workspace, to account for switching animations
+                let sample_area =
+                    Rectangle::new(window_geometry.loc + render_offset, window_geometry.size);
+
+                BlurElement::new(
+                    renderer,
+                    output,
+                    sample_area,
+                    window_geometry.loc.to_physical(scale),
+                    border_radius,
+                    optimized,
+                    scale,
+                    alpha,
+                    blur,
+                )
+                .into()
+            })
+            .into_iter();
+
+        let shadow_element = shadow
+            .and_then(|shadow| {
+                let should_draw = if shadow.disable {
+                    false
+                } else {
+                    match shadow.floating_only {
+                        true => is_floating,
+                        false => true,
+                    }
+                };
+
+                if !is_fullscreen && shadow.color[3] > 0.0 && should_draw {
+                    Some(
+                        super::decorations::draw_shadow(
+                            renderer,
+                            alpha,
+                            scale,
+                            window_geometry,
+                            shadow.sigma,
+                            border_radius,
+                            shadow.color,
+                        )
+                        .into(),
+                    )
+                } else {
+                    None
+                }
+            })
+            .into_iter();
+
+        opening_element
+            .into_iter()
+            .chain(normal_elements)
+            .chain(border_element)
+            .chain(blur_element)
+            .chain(shadow_element)
     }
 }
 

--- a/src/space/workspace.rs
+++ b/src/space/workspace.rs
@@ -658,7 +658,7 @@ impl Workspace {
         // Now, based on which quadrant of the closest tile we are in, we determine where to insert
         // the final tile. So you can place the tile between two files, for example.
         let cursor_position_in_tile = (cursor_position - closest_tile.location()).to_f64();
-        let size = tile.size().to_f64();
+        let size = closest_tile.size().to_f64();
         let mut edges = ResizeEdge::empty();
         if cursor_position_in_tile.x < size.w / 3. {
             edges |= ResizeEdge::LEFT;

--- a/src/space/workspace.rs
+++ b/src/space/workspace.rs
@@ -674,11 +674,26 @@ impl Workspace {
         // The actual handling depends on the layout.
         match self.current_layout() {
             WorkspaceLayout::Tile => {
-                // In the master layout, there are the following cases:
-                // - Insert the tile in the slave stack
-                // - Insert the tile in the master stack, and incrementing nmaster by one.
                 if closest_idx < self.nmaster {
-                    if edges.intersects(ResizeEdge::BOTTOM) {
+                    if edges.intersects(ResizeEdge::RIGHT) && self.nmaster == self.tiles.len() {
+                        // We need a way to create a slave stack when there are only masters window,
+                        // this condition covers the following case:
+                        //
+                        // (the X marks where the cursor could be)
+                        //
+                        // +--------------------+
+                        // |              XXXXXX|
+                        // |              XXXXXX|
+                        // +--------------------+
+                        // +--------------------+
+                        // |              XXXXXX|
+                        // |              XXXXXX|
+                        // +--------------------+
+                        //
+                        // In this case we want to create a stack stack
+                        self.active_tile_idx = Some(self.tiles.len());
+                        self.tiles.push(tile);
+                    } else if edges.intersects(ResizeEdge::BOTTOM) {
                         // Insert after this master window.
                         self.nmaster += 1;
                         self.active_tile_idx = Some(closest_idx + 1);

--- a/src/space/workspace.rs
+++ b/src/space/workspace.rs
@@ -632,6 +632,18 @@ impl Workspace {
             return;
         }
 
+        if let Some(_) = self
+            .fullscreened_tile_idx
+            .and_then(|idx| self.tiles.get(idx))
+        {
+            let idx = self.fullscreened_tile_idx.unwrap();
+            // If there's a fullscreened tile, just insert it and unfullscreen
+            self.remove_current_fullscreen();
+            self.tiles.insert(idx, tile);
+
+            return;
+        }
+
         // First we need to first the closest tile.
         let (cursor_x, cursor_y) = cursor_position.into();
         let (closest_idx, closest_tile) = self

--- a/src/space/workspace.rs
+++ b/src/space/workspace.rs
@@ -807,7 +807,7 @@ impl Workspace {
         };
 
         let scale = self.output.current_scale().integer_scale();
-        tile.prepare_close_animation_if_needed(&self.output, renderer, scale);
+        tile.prepare_close_animation_if_needed(renderer, scale);
 
         true
     }

--- a/src/space/workspace.rs
+++ b/src/space/workspace.rs
@@ -622,7 +622,6 @@ impl Workspace {
     pub(super) fn insert_tile_with_cursor_position(
         &mut self,
         tile: Tile,
-        previous_idx: usize,
         cursor_position: Point<i32, Logical>,
     ) {
         if self.tiles.is_empty() || !tile.window().tiled() {
@@ -710,8 +709,6 @@ impl Workspace {
                         // First insert the grabbed tile.
                         self.active_tile_idx = Some(closest_idx);
                         self.tiles.insert(closest_idx, tile);
-                        // Then swap the closest one.
-                        self.tiles.swap(closest_idx + 1, previous_idx);
                     }
                 } else {
                     if edges.intersects(ResizeEdge::BOTTOM) {
@@ -729,8 +726,6 @@ impl Workspace {
                         // First insert the grabbed tile.
                         self.active_tile_idx = Some(closest_idx);
                         self.tiles.insert(closest_idx, tile);
-                        // Then swap the closest one.
-                        self.tiles.swap(closest_idx + 1, previous_idx);
                     }
                 }
 
@@ -772,8 +767,6 @@ impl Workspace {
                         // First insert the grabbed tile.
                         self.active_tile_idx = Some(closest_idx);
                         self.tiles.insert(closest_idx, tile);
-                        // Then swap the closest one.
-                        self.tiles.swap(closest_idx + 1, previous_idx);
                     }
                 } else {
                     if edges.intersects(ResizeEdge::RIGHT) {
@@ -791,8 +784,6 @@ impl Workspace {
                         // First insert the grabbed tile.
                         self.active_tile_idx = Some(closest_idx);
                         self.tiles.insert(closest_idx, tile);
-                        // Then swap the closest one.
-                        self.tiles.swap(closest_idx + 1, previous_idx);
                     }
                 }
 
@@ -835,8 +826,6 @@ impl Workspace {
                         // First insert the grabbed tile.
                         self.active_tile_idx = Some(closest_idx);
                         self.tiles.insert(closest_idx, tile);
-                        // Then swap the closest one.
-                        self.tiles.swap(closest_idx + 1, previous_idx);
                     }
                 } else {
                     // Centered master layout is way too confusing to get something that works right
@@ -844,7 +833,6 @@ impl Workspace {
                     // stack.
                     self.active_tile_idx = Some(closest_idx);
                     self.tiles.insert(closest_idx, tile);
-                    self.tiles.swap(closest_idx + 1, previous_idx);
                 }
 
                 self.arrange_tiles(true);
@@ -1603,7 +1591,7 @@ impl Workspace {
     /// Start an interactive swap grab.
     ///
     /// Returns [`true`] if the grab was successfully registered.
-    pub(super) fn start_interactive_swap(&mut self, window: &Window) -> Option<(usize, Tile)> {
+    pub(super) fn start_interactive_swap(&mut self, window: &Window) -> Option<Tile> {
         let Some(idx) = self.tiles.iter().position(|tile| tile.window() == window) else {
             // Can't find the adequate tile
             return None;
@@ -1620,7 +1608,7 @@ impl Workspace {
             self.nmaster = (self.nmaster - 1).max(1);
         }
         self.arrange_tiles(true);
-        Some((idx, tile))
+        Some(tile)
     }
 
     /// Start an interactive resize grab.

--- a/src/state.rs
+++ b/src/state.rs
@@ -264,12 +264,10 @@ impl State {
             // Clear the output its opened on
             let _ = self.fht.config_ui_output.take_if(|_| !ongoing);
 
-            let monitor = self
+            ongoing |= self
                 .fht
                 .space
-                .monitor_mut_for_output(&output)
-                .expect("all outputs should be tracked by Space");
-            ongoing |= monitor.advance_animations(target_presentation_time);
+                .advance_animations(target_presentation_time, &output);
 
             ongoing
         };


### PR DESCRIPTION
Title. This pull request implements this by moving the responsibility of managing the grab from the `Workspace` to the `Space` so that we have easy access to the swapped tile at all times.

There are still some small issues with this approach notably:
- If there's part of a tile that's shown between two outputs, and release it on another, it will awkwardly disappear from the other outputs (except the one you dropped it at)
- Sometimes tiles might not pick up new output presentation framerates IE. not update in sync with the new output