### PR TITLE
Feat: IPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -991,6 +991,7 @@ name = "fht-compositor-ipc"
 version = "25.3.1"
 dependencies = [
  "anyhow",
+ "clap",
  "serde",
  "serde_json",
  "smithay",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -988,6 +988,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "fht-compositor-ipc"
+version = "25.3.1"
+dependencies = [
+ "anyhow",
+]
+
+[[package]]
 name = "foreign-types"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -25,10 +25,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
  "once_cell",
  "version_check",
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -135,9 +135,9 @@ dependencies = [
 
 [[package]]
 name = "anyhow"
-version = "1.0.96"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6b964d184e89d9b6b67dd2715bc8e74cf3107fb2b529990c90cf517326150bf4"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "appendlist"
@@ -230,7 +230,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix",
+ "rustix 0.38.44",
  "slab",
  "tracing",
  "windows-sys 0.59.0",
@@ -262,7 +262,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix",
+ "rustix 0.38.44",
  "tracing",
 ]
 
@@ -289,7 +289,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix",
+ "rustix 0.38.44",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.59.0",
@@ -303,9 +303,9 @@ checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
-version = "0.1.86"
+version = "0.1.88"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "644dd749086bf3771a2fbc5f256fdb982d53f011c7d5d560304eafeecebce79d"
+checksum = "e539d3fca749fcee5236ab05e93a52867dd549cc157c8cb7f99595f3cedffdb5"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -387,18 +387,18 @@ checksum = "1628fb46dfa0b37568d12e5edd512553eccf6a22a78e8bde00bb4aed84d5bdbf"
 
 [[package]]
 name = "bytemuck"
-version = "1.21.0"
+version = "1.22.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef657dfab802224e671f5818e9a4935f9b1957ed18e58292690cc39e7a4092a3"
+checksum = "b6b1fc10dbac614ebc03540c9dbd60e83887fda27794998c6528f1782047d540"
 dependencies = [
  "bytemuck_derive",
 ]
 
 [[package]]
 name = "bytemuck_derive"
-version = "1.8.1"
+version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fa76293b4f7bb636ab88fd78228235b5248b4d05cc589aed610f954af5d7c7a"
+checksum = "7ecc273b49b3205b83d648f0690daa588925572cc5063745bfe547fe7ec8e1a1"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -406,16 +406,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "byteorder"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
-
-[[package]]
 name = "bytes"
-version = "1.10.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f61dac84819c6588b558454b194026eb1f09c293b9036ae9b159e74e73ab6cf9"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "calloop"
@@ -426,7 +420,7 @@ dependencies = [
  "bitflags 2.9.0",
  "log",
  "polling",
- "rustix",
+ "rustix 0.38.44",
  "slab",
  "thiserror 1.0.69",
 ]
@@ -441,7 +435,7 @@ dependencies = [
  "bitflags 2.9.0",
  "futures-io",
  "polling",
- "rustix",
+ "rustix 0.38.44",
  "slab",
  "tracing",
 ]
@@ -453,16 +447,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95a66a987056935f7efce4ab5668920b5d0dac4a7c99991a67395f13702ddd20"
 dependencies = [
  "calloop 0.13.0",
- "rustix",
+ "rustix 0.38.44",
  "wayland-backend",
  "wayland-client",
 ]
 
 [[package]]
 name = "cc"
-version = "1.2.16"
+version = "1.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be714c154be609ec7f5dad223a33bf1482fff90472de28f7362806e6d4832b8c"
+checksum = "04da6a0d40b948dfc4fa8f5bbf402b0fc1a64a28dbf7d12ffd683550f2c1b63a"
 dependencies = [
  "jobserver",
  "libc",
@@ -539,9 +533,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.31"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "027bb0d98429ae334a8698531da7077bdf906419543a35a55c2cb1b66437d767"
+checksum = "eccb054f56cbd38340b380d4a8e69ef1f02f1af43db2f0cc817a4774d80ae071"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -549,30 +543,30 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.31"
+version = "4.5.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5589e0cba072e0f3d23791efac0fd8627b49c829c196a492e88168e6a669d863"
+checksum = "efd9466fac8543255d3b1fcad4762c5e116ffe808c8a3043d4263cd4fd4862a2"
 dependencies = [
  "anstream",
  "anstyle",
  "clap_lex",
- "strsim 0.11.1",
+ "strsim",
 ]
 
 [[package]]
 name = "clap_complete"
-version = "4.5.46"
+version = "4.5.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f5c5508ea23c5366f77e53f5a0070e5a84e51687ec3ef9e0464c86dc8d13ce98"
+checksum = "c06f5378ea264ad4f82bbc826628b5aad714a75abf6ece087e923010eb937fb6"
 dependencies = [
  "clap",
 ]
 
 [[package]]
 name = "clap_derive"
-version = "4.5.28"
+version = "4.5.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+checksum = "09176aae279615badda0765c0c0b3f6ed53f4709118af73cf4655d85d1530cd7"
 dependencies = [
  "heck",
  "proc-macro2",
@@ -749,7 +743,7 @@ dependencies = [
  "drm-ffi",
  "drm-fourcc",
  "libc",
- "rustix",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -759,7 +753,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8e41459d99a9b529845f6d2c909eb9adf3b6d2f82635ae40be8de0601726e8b"
 dependencies = [
  "drm-sys",
- "rustix",
+ "rustix 0.38.44",
 ]
 
 [[package]]
@@ -780,9 +774,9 @@ dependencies = [
 
 [[package]]
 name = "ecolor"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "878e9005799dd739e5d5d89ff7480491c12d0af571d44399bcaefa1ee172dd76"
+checksum = "bc4feb366740ded31a004a0e4452fbf84e80ef432ecf8314c485210229672fd1"
 dependencies = [
  "bytemuck",
  "emath",
@@ -790,9 +784,9 @@ dependencies = [
 
 [[package]]
 name = "egui"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d2768eaa6d5c80a6e2a008da1f0e062dff3c83eb2b28605ea2d0732d46e74d6"
+checksum = "25dd34cec49ab55d85ebf70139cb1ccd29c977ef6b6ba4fe85489d6877ee9ef3"
 dependencies = [
  "ahash",
  "bitflags 2.9.0",
@@ -804,9 +798,9 @@ dependencies = [
 
 [[package]]
 name = "egui_glow"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a53e2374a964c3c793cb0b8ead81bca631f24974bc0b747d1a5622f4e39fdd0"
+checksum = "910906e3f042ea6d2378ec12a6fd07698e14ddae68aed2d819ffe944a73aab9e"
 dependencies = [
  "ahash",
  "bytemuck",
@@ -821,15 +815,15 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7914353092ddf589ad78f25c5c1c21b7f80b0ff8621e7c814c3485b5306da9d"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "emath"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55b7b6be5ad1d247f11738b0e4699d9c20005ed366f2c29f5ec1f8e1de180bc2"
+checksum = "9e4cadcff7a5353ba72b7fea76bf2122b5ebdbc68e8155aa56dfdea90083fe1b"
 dependencies = [
  "bytemuck",
 ]
@@ -863,9 +857,9 @@ dependencies = [
 
 [[package]]
 name = "epaint"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "275b665a7b9611d8317485187e5458750850f9e64604d3c58434bb3fc1d22915"
+checksum = "41fcc0f5a7c613afd2dee5e4b30c3e6acafb8ad6f0edb06068811f708a67c562"
 dependencies = [
  "ab_glyph",
  "ahash",
@@ -880,9 +874,9 @@ dependencies = [
 
 [[package]]
 name = "epaint_default_fonts"
-version = "0.31.0"
+version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9343d356d7cac894dacafc161b4654e0881301097bdf32a122ed503d97cb94b6"
+checksum = "fc7e7a64c02cf7a5b51e745a9e45f60660a286f151c238b9d397b3e923f5082f"
 
 [[package]]
 name = "equivalent"
@@ -892,9 +886,9 @@ checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
 
 [[package]]
 name = "errno"
-version = "0.3.10"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
+checksum = "976dd42dc7e85965fe702eb8164f21f450704bdde31faefd6471dba214cb594e"
 dependencies = [
  "libc",
  "windows-sys 0.59.0",
@@ -913,9 +907,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.3"
+version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
 dependencies = [
  "event-listener",
  "pin-project-lite",
@@ -933,7 +927,7 @@ version = "0.1.0"
 source = "git+https://github.com/nferhat/fht-animation#d64c1efd3461e27e1475ace7bbf125a298cd192c"
 dependencies = [
  "keyframe",
- "rustix",
+ "rustix 0.38.44",
  "serde",
 ]
 
@@ -1180,9 +1174,9 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.15"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
+checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
  "libc",
@@ -1191,14 +1185,14 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43a49c392881ce6d5c3b8cb70f98717b7c07aabbdff06687b9030dbfbe2725f8"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi 0.13.3+wasi-0.2.2",
- "windows-targets 0.52.6",
+ "r-efi",
+ "wasi 0.14.2+wasi-0.2.4",
 ]
 
 [[package]]
@@ -1268,9 +1262,9 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "indexmap"
-version = "2.7.1"
+version = "2.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c9c992b02b5b4c94ea26e32fe5bccb7aa7d9f390ab5c1221ff895bc7ea8b652"
+checksum = "cea70ddb795996207ad57735b50c5982d8844f38ba9ee5f1aedcfb708a2aa11e"
 dependencies = [
  "equivalent",
  "hashbrown",
@@ -1350,10 +1344,11 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.32"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
+checksum = "38f262f097c174adebe41eb73d66ae9c06b2844fb0da69969647bbddd9b0538a"
 dependencies = [
+ "getrandom 0.3.2",
  "libc",
 ]
 
@@ -1396,9 +1391,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.170"
+version = "0.2.172"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "875b3680cb2f8f71bdcf9a30f38d48282f5d3c95cbf9b3fa57269bb5d5c06828"
+checksum = "d750af042f7ef4f724306de029d18836c26c1765a54a6a3f094cbd23a7267ffa"
 
 [[package]]
 name = "libdisplay-info"
@@ -1410,7 +1405,7 @@ dependencies = [
  "libc",
  "libdisplay-info-derive",
  "libdisplay-info-sys",
- "thiserror 2.0.11",
+ "thiserror 2.0.12",
 ]
 
 [[package]]
@@ -1446,9 +1441,9 @@ dependencies = [
 
 [[package]]
 name = "libm"
-version = "0.2.11"
+version = "0.2.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
+checksum = "c9627da5196e5d8ed0b0495e61e518847578da83483c37288316d9b2e03a7f72"
 
 [[package]]
 name = "libredox"
@@ -1458,7 +1453,7 @@ checksum = "c0ff37bd590ca25063e35af745c343cb7a0271906fb7b37e4813e8f79f00268d"
 dependencies = [
  "bitflags 2.9.0",
  "libc",
- "redox_syscall 0.5.9",
+ "redox_syscall 0.5.11",
 ]
 
 [[package]]
@@ -1530,6 +1525,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a385b1be4e5c3e362ad2ffa73c392e53f031eaa5b7d648e64cd87f27f6063d7"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd945864f07fe9f5371a27ad7b52a172b4b499999f1d97574c9fa68373937e12"
+
+[[package]]
 name = "lock_api"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1541,9 +1542,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.26"
+version = "0.4.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30bde2b3dc3671ae49d8e2e9f044c7c005836e7a023ee57cffa25ab82764bb9e"
+checksum = "13dc2df351e3202783a1fe0d44375f7295ffb4049267b0f3018346dc122a1d94"
 
 [[package]]
 name = "loom"
@@ -1902,9 +1903,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.20.3"
+version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "945462a4b81e43c4e3ba96bd7b49d834c6f61198356aa858733bc4acf3cbe62e"
+checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "orbclient"
@@ -1973,7 +1974,7 @@ checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.9",
+ "redox_syscall 0.5.11",
  "smallvec",
  "windows-targets 0.52.6",
 ]
@@ -2028,18 +2029,18 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfe2e71e1471fe07709406bf725f710b02927c9c54b2b5b2ec0e8087d97c327d"
+checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.9"
+version = "1.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6e859e6e5bd50440ab63c47e3ebabc90f26251f7c73c3d3e837b74a1cc3fa67"
+checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2097,9 +2098,9 @@ dependencies = [
 
 [[package]]
 name = "pkg-config"
-version = "0.3.31"
+version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "953ec861398dccce10c670dfeaf3ec4911ca479e9c02154b3a215178c5f566f2"
+checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
 
 [[package]]
 name = "polling"
@@ -2111,34 +2112,34 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi 0.4.0",
  "pin-project-lite",
- "rustix",
+ "rustix 0.38.44",
  "tracing",
  "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.20"
+version = "0.2.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
+checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.8.25",
 ]
 
 [[package]]
 name = "proc-macro-crate"
-version = "3.2.0"
+version = "3.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ecf48c7ca261d60b74ab1a7b20da18bede46776b2e55535cb958eb595c5fa7b"
+checksum = "edce586971a4dfaa28950c6f18ed55e0406c1ab88bbce2c6f6293a7aaba73d35"
 dependencies = [
  "toml_edit",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.93"
+version = "1.0.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
+checksum = "02b3e5e68a3a1a02aad3ec490a98007cbc13c37cbe84a3cd7b8e406d76e7f778"
 dependencies = [
  "unicode-ident",
 ]
@@ -2164,21 +2165,27 @@ dependencies = [
 
 [[package]]
 name = "quick-xml"
-version = "0.37.2"
+version = "0.37.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "165859e9e55f79d67b96c5d96f4e88b6f2695a1972849c15a6a3f5c59fc2c003"
+checksum = "a4ce8c88de324ff838700f36fb6ab86c96df0e3c4ab6ef3a9b2044465cce1369"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.38"
+version = "1.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
+checksum = "1885c039570dc00dcb4ff087a89e185fd56bae234ddc7f056a945bf36467248d"
 dependencies = [
  "proc-macro2",
 ]
+
+[[package]]
+name = "r-efi"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
@@ -2207,7 +2214,7 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.15",
+ "getrandom 0.2.16",
 ]
 
 [[package]]
@@ -2227,9 +2234,9 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.9"
+version = "0.5.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "82b568323e98e49e2a0899dcee453dd679fae22d69adf9b11dd508d1549b7e2f"
+checksum = "d2f103c6d277498fbceb16e84d317e2a400f160f46904d5f5410848c829511a3"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -2298,10 +2305,23 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustversion"
-version = "1.0.19"
+name = "rustix"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
+checksum = "d97817398dd4bb2e6da002002db259209759911da105da92bec29ccb12cf58bf"
+dependencies = [
+ "bitflags 2.9.0",
+ "errno",
+ "libc",
+ "linux-raw-sys 0.9.4",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "rustversion"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eded382c5f5f786b989652c49544c4877d9f015cc22e145a5ea8ea66c2921cd2"
 
 [[package]]
 name = "ryu"
@@ -2341,24 +2361,24 @@ dependencies = [
 
 [[package]]
 name = "semver"
-version = "1.0.25"
+version = "1.0.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
+checksum = "56e6fa9c48d24d85fb3de5ad847117517440f6beceb7798af16b4a87d616b8d0"
 
 [[package]]
 name = "serde"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8dfc9d19bdbf6d17e22319da49161d5d0108e4188e8b680aef6299eed22df60"
+checksum = "5f0e2c6ed6606019b4e29e69dbaba95b11854410e5347d525002456dbbb786b6"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.218"
+version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09503e191f4e797cb8aac08e9a4a4695c5edf6a2e70e376d961ddd5c969f82b"
+checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2414,9 +2434,9 @@ checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.2"
+version = "1.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+checksum = "9203b8055f63a2a00e2f593bb0510367fe707d7ff1e5c872de2f537b339e5410"
 dependencies = [
  "libc",
 ]
@@ -2447,9 +2467,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.14.0"
+version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fcf8323ef1faaee30a44a340193b1ac6814fd9b7b4e88e9d4519a3e4abe1cfd"
+checksum = "8917285742e9f3e1683f0a9c4e6b57960b7314d0b08d30d1ecd426713ee2eee9"
 
 [[package]]
 name = "smithay"
@@ -2480,7 +2500,7 @@ dependencies = [
  "pkg-config",
  "profiling",
  "rand",
- "rustix",
+ "rustix 0.38.44",
  "scopeguard",
  "smallvec",
  "tempfile",
@@ -2513,7 +2533,7 @@ dependencies = [
  "libc",
  "log",
  "memmap2",
- "rustix",
+ "rustix 0.38.44",
  "thiserror 1.0.69",
  "wayland-backend",
  "wayland-client",
@@ -2545,9 +2565,9 @@ dependencies = [
 
 [[package]]
 name = "sscanf"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a147d3cf7e723671ed11355b5b008c8019195f7fc902e213f5557d931e9f839d"
+checksum = "cbd1009b536a04035c8ffcf967496c7726c6b4971c9939b20ad085ac9377d4f0"
 dependencies = [
  "const_format",
  "lazy_static",
@@ -2557,15 +2577,15 @@ dependencies = [
 
 [[package]]
 name = "sscanf_macro"
-version = "0.4.2"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af3a37bdf8e90e77cc60f74473edf28d922ae2eacdd595e67724ccd2381774cc"
+checksum = "cffce0630a574bbcda2476cf733363c7e077001c386b0dea87b77eb397ca1a37"
 dependencies = [
  "convert_case",
  "proc-macro2",
  "quote",
  "regex-syntax 0.6.29",
- "strsim 0.10.0",
+ "strsim",
  "syn",
  "unicode-width",
 ]
@@ -2584,21 +2604,15 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "strsim"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
-
-[[package]]
-name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "syn"
-version = "2.0.98"
+version = "2.0.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "36147f1a48ae0ec2b5b3bc5b537d267457555a10dc06f3dbc8cb11ba3006d3b1"
+checksum = "b09a44accad81e1ba1cd74a32461ba89dee89095ba17b32f5d03683b1b1fc2a0"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2639,15 +2653,14 @@ checksum = "61c41af27dd6d1e27b1b16b489db798443478cef1f06a660c96db617ba5de3b1"
 
 [[package]]
 name = "tempfile"
-version = "3.17.1"
+version = "3.19.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e5a0acb1f3f55f65cc4a866c361b2fb2a0ff6366785ae6fbb5f85df07ba230"
+checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
 dependencies = [
- "cfg-if",
  "fastrand",
- "getrandom 0.3.1",
+ "getrandom 0.3.2",
  "once_cell",
- "rustix",
+ "rustix 1.0.5",
  "windows-sys 0.59.0",
 ]
 
@@ -2662,11 +2675,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d452f284b73e6d76dd36758a0c8684b1d5be31f92b89d07fd5822175732206fc"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.11",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -2682,9 +2695,9 @@ dependencies = [
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.11"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26afc1baea8a989337eeb52b6e72a039780ce45c3edfcc9c5b9d112feeb173c2"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2703,9 +2716,9 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.20"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cd87a5cdd6ffab733b2f74bc4fd7ee5fff6634124999ac278c35fc78c6120148"
+checksum = "900f6c86a685850b1bc9f6223b20125115ee3f31e01207d81655bbcc0aea9231"
 dependencies = [
  "serde",
  "serde_spanned",
@@ -2715,25 +2728,32 @@ dependencies = [
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.8"
+version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+checksum = "3da5db5a963e24bc68be8b17b6fa82814bb22ee8660f192bb182771d498f09a3"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.24"
+version = "0.22.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "17b4795ff5edd201c7cd6dca065ae59972ce77d1b80fa0a84d94950ece7d1474"
+checksum = "10558ed0bd2a1562e630926a2d1f0b98c827da99fabd3fe20920a59642504485"
 dependencies = [
  "indexmap",
  "serde",
  "serde_spanned",
  "toml_datetime",
+ "toml_write",
  "winnow",
 ]
+
+[[package]]
+name = "toml_write"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28391a4201ba7eb1984cfeb6862c0b3ea2cfe23332298967c749dddc0d6cd976"
 
 [[package]]
 name = "tracing"
@@ -2849,9 +2869,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "00e2473a93778eb0bad35909dff6a10d28e63f792f16ed15e404fca9d5eeedbe"
+checksum = "5a5f39404a5da50712a4c1eecf25e90dd62b613502b7e925fd4e4d19b5c96512"
 
 [[package]]
 name = "unicode-segmentation"
@@ -2913,9 +2933,9 @@ checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
 name = "wasi"
-version = "0.13.3+wasi-0.2.2"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26816d2e1a4a36a2940b96c5296ce403917633dff8f3440e9b236ed6f6bacad2"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
  "wit-bindgen-rt",
 ]
@@ -2999,7 +3019,7 @@ checksum = "b7208998eaa3870dad37ec8836979581506e0c5c64c20c9e79e9d2a10d6f47bf"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix",
+ "rustix 0.38.44",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -3012,7 +3032,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2120de3d33638aaef5b9f4472bff75f07c56379cf76ea320bd3a3d65ecaf73f"
 dependencies = [
  "bitflags 2.9.0",
- "rustix",
+ "rustix 0.38.44",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -3034,7 +3054,7 @@ version = "0.31.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a93029cbb6650748881a00e4922b076092a6a08c11e7fbdb923f064b23968c5d"
 dependencies = [
- "rustix",
+ "rustix 0.38.44",
  "wayland-client",
  "xcursor",
 ]
@@ -3121,7 +3141,7 @@ checksum = "97fabd7ed68cff8e7657b8a8a1fbe90cb4a3f0c30d90da4bf179a7a23008a4cb"
 dependencies = [
  "bitflags 2.9.0",
  "downcast-rs",
- "rustix",
+ "rustix 0.38.44",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -3501,7 +3521,7 @@ dependencies = [
  "pin-project",
  "raw-window-handle",
  "redox_syscall 0.4.1",
- "rustix",
+ "rustix 0.38.44",
  "smithay-client-toolkit",
  "smol_str",
  "tracing",
@@ -3522,18 +3542,18 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.3"
+version = "0.7.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7f4ea97f6f78012141bcdb6a216b2609f0979ada50b20ca5b52dde2eac2bb1"
+checksum = "6cb8234a863ea0e8cd7284fcdd4f145233eb00fee02bbdd9861aec44e6477bc5"
 dependencies = [
  "memchr",
 ]
 
 [[package]]
 name = "wit-bindgen-rt"
-version = "0.33.0"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3268f3d866458b787f390cf61f4bbb563b922d091359f9608842999eaee3943c"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
 dependencies = [
  "bitflags 2.9.0",
 ]
@@ -3560,7 +3580,7 @@ dependencies = [
  "libc",
  "libloading",
  "once_cell",
- "rustix",
+ "rustix 0.38.44",
  "x11rb-protocol",
 ]
 
@@ -3624,9 +3644,9 @@ checksum = "b9cc00251562a284751c9973bace760d86c0276c471b4be569fe6b068ee97a56"
 
 [[package]]
 name = "xml-rs"
-version = "0.8.25"
+version = "0.8.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5b940ebc25896e71dd073bad2dbaa2abfe97b0a391415e22ad1326d9c54e3c4"
+checksum = "a62ce76d9b56901b19a74f19431b0d8b3bc7ca4ad685a746dfd78ca8f4fc6bda"
 
 [[package]]
 name = "yansi-term"
@@ -3706,8 +3726,16 @@ version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "byteorder",
- "zerocopy-derive",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1702d9583232ddb9174e01bb7c15a2ab8fb1bc6f227aa1233858c351a3ba0cb"
+dependencies = [
+ "zerocopy-derive 0.8.25",
 ]
 
 [[package]]
@@ -3715,6 +3743,17 @@ name = "zerocopy-derive"
 version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28a6e20d751156648aa063f3800b706ee209a32c0b4d9f24be3d980b01be55ef"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -773,6 +773,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dyn-clone"
+version = "1.0.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c7a8fb8a9fbf66c1f703fe16184d10ca0ee9d23be5b4436400408ba54a95005"
+
+[[package]]
 name = "ecolor"
 version = "0.31.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -992,6 +998,7 @@ version = "25.3.1"
 dependencies = [
  "anyhow",
  "clap",
+ "schemars",
  "serde",
  "serde_json",
  "smithay",
@@ -2243,6 +2250,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a0ae411dbe946a674d89546582cea4ba2bb8defac896622d6496f14c23ba5cf"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1165225c21bff1f3bbce98f5a1f889949bc902d3575308cc7b0de30b4f6d27c7"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2340,6 +2367,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82d20c4491bc164fa2f6c5d44565947a52ad80b9505d8e36f8d54c27c739fcd0"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33d020396d1d138dc19f1165df7545479dcd58d93810dc5d646a16e55abefa80"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scoped-tls"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2380,6 +2432,17 @@ name = "serde_derive"
 version = "1.0.219"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b0276cf7f2c73365f7157c8123c21cd9a50fbbd844757af28ca1f5925fc2a00"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,7 +437,9 @@ version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10929724661d1c43856fd87c7a127ae944ec55579134fb485e4136fb6a46fdcb"
 dependencies = [
+ "async-task",
  "bitflags 2.9.0",
+ "futures-io",
  "polling",
  "rustix",
  "slab",
@@ -943,6 +945,7 @@ dependencies = [
  "async-channel",
  "async-io",
  "bitflags 2.9.0",
+ "calloop 0.14.2",
  "clap",
  "clap_complete",
  "drm-ffi",
@@ -950,6 +953,8 @@ dependencies = [
  "egui_glow",
  "fht-animation",
  "fht-compositor-config",
+ "fht-compositor-ipc",
+ "futures-util",
  "glam",
  "libc",
  "libdisplay-info",
@@ -992,6 +997,9 @@ name = "fht-compositor-ipc"
 version = "25.3.1"
 dependencies = [
  "anyhow",
+ "serde",
+ "serde_json",
+ "smithay",
 ]
 
 [[package]]
@@ -1314,9 +1322,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.14"
+version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
+checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jni"
@@ -2297,9 +2305,9 @@ checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ryu"
-version = "1.0.19"
+version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea1a2d0a644769cc99faa24c3ad26b379b786fe7c36fd3c546254801650e6dd"
+checksum = "28d3b2b1366ec20994f1fd18c3c594f05c5dd4bc44d8bb0c1c632c8d6829481f"
 
 [[package]]
 name = "same-file"
@@ -2359,9 +2367,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.139"
+version = "1.0.140"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44f86c3acccc9c65b153fe1b85a3be07fe5515274ec9f0653b4a0875731c72a6"
+checksum = "20068b6e96dc6c9bd23e01df8827e6c7e1f2fddd43c21810382803c136b99373"
 dependencies = [
  "itoa",
  "memchr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,9 @@ smithay = { workspace = true, features = [
     "backend_gbm",      # required for pipewire madness
     "use_system_lib",
     "backend_egl",      # EGL support for wayland
+    "use_system_lib",
+    "backend_egl",      # EGL support for wayland
+    "backend_gbm",      # libgbm, needed for many things
     "backend_libinput", # Input handling
 ] }
 smithay-drm-extras = { workspace = true, optional = true }
@@ -99,7 +102,7 @@ drm-ffi = "0.9.0"
 sd-notify = { version = "0.4.5", optional = true }
 
 [features]
-default = ["winit-backend", "udev-backend", "all-portals"]
+default = ["winit-backend", "udev-backend", "headless-backend", "all-portals"]
 
 # Marker feature to enable D-Bus connectivity.
 #
@@ -133,6 +136,12 @@ udev-backend = [
     "smithay/backend_session_libseat",
     "smithay/renderer_multi",
 ]
+
+# A headless backend.
+# ---
+# This backend is for pure testing purposes. You are not expected to use this nor to compile this.
+# It's used when testing the IPC and stuff that doesn't require a graphical instance running
+headless-backend = []
 
 # Enable profiling with tracy
 #

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 # {{{ Workspace
 
 [workspace]
-members = ["fht-compositor-config"]
+members = ["fht-compositor-config", "fht-compositor-ipc"]
 resolver = "2"
 
 [workspace.package]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,10 @@ repository = "https://github.com/nferhat/fht-compositor"
 
 [workspace.dependencies]
 anyhow = "1.0.79"
-# Basic logging setup
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
-# Config file support
+serde_json = "1.0.134"
+serde = { version = "1.0.217", features = ["derive"] }
 
 [workspace.dependencies.smithay]
 git = "https://github.com/smithay/Smithay"
@@ -68,6 +68,7 @@ smithay = { workspace = true, features = [
     "backend_gbm",      # libgbm, needed for many things
     "backend_libinput", # Input handling
 ] }
+calloop = { version = "0.14.2", features = ["executor", "futures-io"] }
 smithay-drm-extras = { workspace = true, optional = true }
 bitflags = "2.6.0"
 thiserror = "1.0.61"
@@ -84,6 +85,9 @@ fht-compositor-config.path = "./fht-compositor-config"
 glam = "0.28.0"
 egui = "0.31"
 egui_glow = "0.31"
+serde.workspace = true
+serde_json.workspace = true
+fht-compositor-ipc.path = "./fht-compositor-ipc"
 fht-animation = { git = "https://github.com/nferhat/fht-animation", version = "0.1.0" }
 # FIXME: We use this instead of std::sync::MappedMutexGuard
 # SEE: tracking issue for nightly flag: https://github.com/rust-lang/rust/issues/117108
@@ -92,14 +96,13 @@ clap = { version = "4.5.18", features = ["derive", "string"] }
 async-channel = "2.3.1"
 async-io = "2.3.4"
 clap_complete = "4.5.38"
-serde_json = "1.0.134"
 xdg = "2.5.2"
-serde = { version = "1.0.217", features = ["derive"] }
 tracy-client = { version = "0.18.0", default-features = false }
 serde_repr = "0.1.20"
 libdisplay-info = "0.2.2"
 drm-ffi = "0.9.0"
 sd-notify = { version = "0.4.5", optional = true }
+futures-util = { version = "0.3.31", features = ["std", "io"] }
 
 [features]
 default = ["winit-backend", "udev-backend", "headless-backend", "all-portals"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ repository = "https://github.com/nferhat/fht-compositor"
 
 [workspace.dependencies]
 anyhow = "1.0.79"
+clap = { version = "4.5.18", features = ["derive", "string"] }
 tracing = "0.1.40"
 tracing-subscriber = { version = "0.3.18", features = ["env-filter"] }
 serde_json = "1.0.134"
@@ -87,14 +88,14 @@ egui = "0.31"
 egui_glow = "0.31"
 serde.workspace = true
 serde_json.workspace = true
-fht-compositor-ipc.path = "./fht-compositor-ipc"
+fht-compositor-ipc = { path = "./fht-compositor-ipc", features = ["clap"] }
 fht-animation = { git = "https://github.com/nferhat/fht-animation", version = "0.1.0" }
 # FIXME: We use this instead of std::sync::MappedMutexGuard
 # SEE: tracking issue for nightly flag: https://github.com/rust-lang/rust/issues/117108
 owning_ref = "0.4.1"
-clap = { version = "4.5.18", features = ["derive", "string"] }
 async-channel = "2.3.1"
 async-io = "2.3.4"
+clap.workspace = true
 clap_complete = "4.5.38"
 xdg = "2.5.2"
 tracy-client = { version = "0.18.0", default-features = false }

--- a/docs/usage/ipc.md
+++ b/docs/usage/ipc.md
@@ -1,5 +1,77 @@
 # IPC
 
-> [!INFO] Work in progress
-> :construction: The IPC system is still a work-in-progress! Nothing stable and working is out yet!<br>
-> Check out the `feat-ipc` branch for status updates!
+`fht-compositor` features a inter-process communication system allowing you fetch data from the
+compositor and modify the live compositor state.
+
+
+You can communicate with this IPC with one of:
+1. `fht-compositor ipc` subcommand in the CLI, `fht-compositor ipc --help` for more information
+
+> [!NOTE]
+> Version mismatches between the compositor and the CLI may cause errors parsing, so when updating
+> make sure to restart your session to make sure both the CLI and compositor are up-to-date.
+>
+> `fht-compositor ipc version` prints both versions, you can use it to check for mismatches.
+>
+> ```sh
+> $ fht-compositor ipc version
+> # Here, both the versions are matching, no need to restart
+> Compositor: 25.03.1 (a17380aa)
+> CLI: 25.03.1 (a17380aa)
+> ````
+
+2. Programmatic access to the IPC, through its Unix socket, useful for scripting or integrating
+  with other parts of your system:
+    * If you are using Rust, use the `fht-compositor-ipc` library directly, as it has all the
+    IPC types pre-defined with `(De)Serialize`.
+    * You can do shell scripting using `socat`, though you'll have to figure out what to write
+    inside the socket yourself.
+
+> [!TIP]
+> To see how the requests/responses are formatted, you can setup and temporary socket and link it
+> with the real one using `socat`.
+>
+> ```sh
+> socat -v UNIX-LISTEN:~/temp.sock,fork UNIX-CONNECT:${FHTC_SOCKET_PATH}
+> # Then, in another terminal, you can connect to ~/temp.sock
+> FHTC_SOCKET_PATH=~/temp.sock fht-compositor ipc version
+> ```
+>
+> You can also use `fht-compositor ipc --json` to see JSON-formatted responses if you only care about
+> that.
+
+## State updates
+
+As of right now, the IPC doesn't support sending live events and updates to the clients, so you will
+have to resort to polling every few seconds.
+
+::: tabs
+== Example with eww
+```yuck
+; Here, we store the space data into a global variable, updated each second.
+; Since eww supports native JSON decoding, this is really handy
+(defpoll space-data :interval "1s"
+                    ; Initital value is empty, to make eww startup fast
+                    :initial "{\"monitors\": {}, \"primary-idx\": -1, \"active-idx\": -1}"
+                    `fht-compositor ipc --json space`)
+
+; Now, somewhere else, you can immediatly use the data to your liking
+(label :text "Output: ${space-data.monitors[0].name}")
+```
+
+== Example with Quickshell
+Taken from [Isabel's Dotfiles](https://github.com/isabelroses/dotfiles)
+```qml
+Process {
+  id: getSelectedWorkspace
+  running: true
+  command: ["fht-compositor", "ipc", "--json", "focused-workspace"]
+  stdout: StdioCollector {
+    onStreamFinished: {
+      var jsonData = JSON.parse(text);
+      // You can now set the actual value somewhere...
+      someVariable = jsonData.id
+    }
+  }
+}
+```

--- a/fht-compositor-ipc/Cargo.toml
+++ b/fht-compositor-ipc/Cargo.toml
@@ -9,3 +9,10 @@ repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+smithay.workspace = true
+
+[[bin]]
+name = "test_client"
+path = "test_client.rs"

--- a/fht-compositor-ipc/Cargo.toml
+++ b/fht-compositor-ipc/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "fht-compositor-ipc"
+version.workspace = true
+description.workspace = true
+authors.workspace = true
+license.workspace = true
+edition.workspace = true
+repository.workspace = true
+
+[dependencies]
+anyhow.workspace = true

--- a/fht-compositor-ipc/Cargo.toml
+++ b/fht-compositor-ipc/Cargo.toml
@@ -10,6 +10,7 @@ repository.workspace = true
 [dependencies]
 anyhow.workspace = true
 clap.workspace = true
+schemars = "1.0.4"
 serde.workspace = true
 serde_json.workspace = true
 smithay.workspace = true

--- a/fht-compositor-ipc/Cargo.toml
+++ b/fht-compositor-ipc/Cargo.toml
@@ -9,9 +9,13 @@ repository.workspace = true
 
 [dependencies]
 anyhow.workspace = true
+clap.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 smithay.workspace = true
+
+[features]
+clap = []
 
 [[bin]]
 name = "test_client"

--- a/fht-compositor-ipc/src/lib.rs
+++ b/fht-compositor-ipc/src/lib.rs
@@ -56,6 +56,10 @@ pub enum Request {
     LayerShells,
     /// Request information about the workspace system.
     Space,
+    /// Request information about a window.
+    Window(usize),
+    /// Request information about a workspace.
+    Workspace(usize),
     /// Request information about the focused window.
     FocusedWindow,
     /// Request information about the focused workspace.
@@ -84,10 +88,10 @@ pub enum Response {
     LayerShells(Vec<LayerShell>),
     /// Space information.
     Space(Space),
-    /// Focused window information.
-    FocusedWindow(Option<Window>),
-    /// Focused workspace information.
-    FocusedWorkspace(Workspace),
+    /// Information about a window.
+    Window(Option<Window>),
+    /// Information about a workspace.
+    Workspace(Option<Workspace>),
     /// The picked window by the user.
     PickedWindow(PickWindowResult),
     /// The picked layer shell by the user.

--- a/fht-compositor-ipc/src/lib.rs
+++ b/fht-compositor-ipc/src/lib.rs
@@ -56,6 +56,10 @@ pub enum Request {
     LayerShells,
     /// Request information about the workspace system.
     Space,
+    /// Request information about the focused window.
+    FocusedWindow,
+    /// Request information about the focused workspace.
+    FocusedWorkspace,
     /// Request the compositor to execute an action.
     Action(Action),
 }
@@ -74,6 +78,10 @@ pub enum Response {
     LayerShells(Vec<LayerShell>),
     /// Space information.
     Space(Space),
+    /// Focused window information.
+    FocusedWindow(Option<Window>),
+    /// Focused workspace information.
+    FocusedWorkspace(Workspace),
     /// There was an error handling the request.
     Error(String),
     /// Noop, for requests that do not need a result/output.

--- a/fht-compositor-ipc/src/lib.rs
+++ b/fht-compositor-ipc/src/lib.rs
@@ -60,6 +60,12 @@ pub enum Request {
     FocusedWindow,
     /// Request information about the focused workspace.
     FocusedWorkspace,
+    /// Request the user to pick a window. On the next click, the information of the window under
+    /// the pointer cursor will be sent back.
+    PickWindow,
+    /// Request the user to pick a layer-shell. On the next click, the information of the
+    /// layer-shell under the pointer cursor will be sent back, if any.
+    PickLayerShell,
     /// Request the compositor to execute an action.
     Action(Action),
 }
@@ -82,6 +88,10 @@ pub enum Response {
     FocusedWindow(Option<Window>),
     /// Focused workspace information.
     FocusedWorkspace(Workspace),
+    /// The picked window by the user.
+    PickedWindow(PickWindowResult),
+    /// The picked layer shell by the user.
+    PickedLayerShell(PickLayerShellResult),
     /// There was an error handling the request.
     Error(String),
     /// Noop, for requests that do not need a result/output.
@@ -607,4 +617,28 @@ pub enum NmasterChange {
     },
     /// Set the nmaster to this value. Clamps at min=1.
     Set { value: usize },
+}
+
+/// The result from picking a [`Window`].
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum PickWindowResult {
+    /// The ID of the picked window
+    Some(usize),
+    /// The user clicked somewhere outside any window.
+    None,
+    /// The pick request was cancelled.
+    Cancelled,
+}
+
+/// The result from picking a [`LayerShell`].
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum PickLayerShellResult {
+    /// The information of the picked layer-shell
+    Some(LayerShell),
+    /// The user clicked somewhere outside any layer-shell.
+    None,
+    /// The pick request was cancelled.
+    Cancelled,
 }

--- a/fht-compositor-ipc/src/lib.rs
+++ b/fht-compositor-ipc/src/lib.rs
@@ -377,12 +377,14 @@ pub enum Action {
     SelectNextLayout {
         /// The [`Workspace::id`] layout to change. Leave as `None` for active workspace
         #[cfg_attr(feature = "clap", arg(long))]
+        #[serde(rename = "workspace-id")]
         workspace_id: Option<usize>,
     },
     /// Select the next available layout in a [`Workspace`]
     SelectPreviousLayout {
         /// The [`Workspace::id`] layout to change. Leave as `None` for active workspace
         #[cfg_attr(feature = "clap", arg(long))]
+        #[serde(rename = "workspace-id")]
         workspace_id: Option<usize>,
     },
     /// Set the maximized state of a window.
@@ -392,6 +394,7 @@ pub enum Action {
         state: Option<bool>,
         /// The [`Window::id`] to toggle maximized on. Leave as `None` for the focused one.
         #[cfg_attr(feature = "clap", arg(long))]
+        #[serde(rename = "window-id")]
         window_id: Option<usize>,
     },
     /// Set the fullscreen state of a window.
@@ -401,6 +404,7 @@ pub enum Action {
         state: Option<bool>,
         /// The [`Window::id`] to toggle fullscreen on. Leave as `None` for the focused one.
         #[cfg_attr(feature = "clap", arg(long))]
+        #[serde(rename = "window-id")]
         window_id: Option<usize>,
     },
     /// Set the floating state of a window.
@@ -410,18 +414,21 @@ pub enum Action {
         state: Option<bool>,
         /// The [`Window::id`] to toggle floating on. Leave as `None` for the focused one.
         #[cfg_attr(feature = "clap", arg(long))]
+        #[serde(rename = "window-id")]
         window_id: Option<usize>,
     },
     /// Center a floating window. If the window is tiled, this does nothing.
     CenterFloatingWindow {
         /// The [`Window::id`] to center on. Leave as `None` for the focused one.
         #[cfg_attr(feature = "clap", arg(long))]
+        #[serde(rename = "window-id")]
         window_id: Option<usize>,
     },
     /// Move a floating window. If the window is tiled, this does nothing.
     MoveFloatingWindow {
         /// The [`Window::id`] to move. Leave as `None` for the focused one.
         #[cfg_attr(feature = "clap", arg(long))]
+        #[serde(rename = "window-id")]
         window_id: Option<usize>,
         // The location change to apply.
         #[cfg_attr(feature = "clap", command(subcommand))]
@@ -431,6 +438,7 @@ pub enum Action {
     ResizeFloatingWindow {
         /// The [`Window::id`] to resize. Leave as `None` for the focused one.
         #[cfg_attr(feature = "clap", arg(long))]
+        #[serde(rename = "window-id")]
         window_id: Option<usize>,
         // The size change to apply.
         #[cfg_attr(feature = "clap", command(subcommand))]
@@ -441,18 +449,21 @@ pub enum Action {
     FocusWindow {
         /// The [`Window::id`] to resize. Leave as `None` for the focused one.
         #[cfg_attr(feature = "clap", arg(long))]
+        #[serde(rename = "window-id")]
         window_id: usize,
     },
     /// Focus the next window in a [`Workspace`].
     FocusNextWindow {
         /// The [`Workspace::id`] layout to change. Leave as `None` for active workspace.
         #[cfg_attr(feature = "clap", arg(long))]
+        #[serde(rename = "workspace-id")]
         workspace_id: Option<usize>,
     },
     /// Focus the previous window in a [`Workspace`].
     FocusPreviousWindow {
         /// The [`Workspace::id`] layout to change. Leave as `None` for active workspace.
         #[cfg_attr(feature = "clap", arg(long))]
+        #[serde(rename = "workspace-id")]
         workspace_id: Option<usize>,
     },
     /// Swap thee currently focused window with the next window in a [`Workspace`].
@@ -462,6 +473,7 @@ pub enum Action {
         keep_focus: bool,
         /// The [`Workspace::id`] layout to change. Leave as `None` for active workspace.
         #[cfg_attr(feature = "clap", arg(long))]
+        #[serde(rename = "workspace-id")]
         workspace_id: Option<usize>,
     },
     /// Swap thee currently focused window with the previous window in a [`Workspace`].
@@ -471,6 +483,7 @@ pub enum Action {
         keep_focus: bool,
         /// The [`Workspace::id`] layout to change. Leave as `None` for active workspace.
         #[cfg_attr(feature = "clap", arg(long))]
+        #[serde(rename = "workspace-id")]
         workspace_id: Option<usize>,
     },
     /// Focus a given output.
@@ -487,11 +500,13 @@ pub enum Action {
     /// Focus a given [`Workspace`]
     FocusWorkspace {
         /// The [`Workspace`] to focus.
+        #[serde(rename = "workspace-id")]
         workspace_id: usize,
     },
     /// Focus a given [`Workspace`] using an index.
     FocusWorkspaceByIndex {
-        /// The [`Workspace`] to focus, referenced by index.
+        /// The [`Workspace`] to focus, r
+        /// #[serde(rename = "workspace-ideferenced by index.
         workspace_idx: usize,
         /// The [`Monitor`] to change the focused [`Workspace`] on. Leave as `None` for the active
         /// one.
@@ -511,6 +526,7 @@ pub enum Action {
     CloseWindow {
         /// The [`Window::id`] to resize. Leave as `None` for the focused one.
         #[cfg_attr(feature = "clap", arg(long))]
+        #[serde(rename = "window-id")]
         window_id: Option<usize>,
         /// Whether to force-kill the window.
         #[cfg_attr(feature = "clap", arg(long, action = clap::ArgAction::Set, default_value_t = false))]
@@ -520,6 +536,7 @@ pub enum Action {
     ChangeMwfact {
         /// The [`Workspace::id`] layout to change. Leave as `None` for active workspace.
         #[cfg_attr(feature = "clap", arg(long))]
+        #[serde(rename = "workspace-id")]
         workspace_id: Option<usize>,
         /// The mwfact change to apply.
         #[cfg_attr(feature = "clap", command(subcommand))]
@@ -529,6 +546,7 @@ pub enum Action {
     ChangeNmaster {
         /// The [`Workspace::id`] layout to change. Leave as `None` for active workspace.
         #[cfg_attr(feature = "clap", arg(long))]
+        #[serde(rename = "workspace-id")]
         workspace_id: Option<usize>,
         /// The nmaster change to apply.
         #[cfg_attr(feature = "clap", command(subcommand))]
@@ -538,6 +556,7 @@ pub enum Action {
     ChangeWindowProportion {
         /// The [`Window::id`] to resize. Leave as `None` for the focused one.
         #[cfg_attr(feature = "clap", arg(long))]
+        #[serde(rename = "window-id")]
         window_id: Option<usize>,
         /// The window proportion change to apply.
         #[cfg_attr(feature = "clap", command(subcommand))]
@@ -547,9 +566,11 @@ pub enum Action {
     SendWindowToWorkspace {
         /// The [`Window::id`] to resize. Leave as `None` for the focused one.
         #[cfg_attr(feature = "clap", arg(long))]
+        #[serde(rename = "window-id")]
         window_id: Option<usize>,
         /// The [`Workspace`] to send the window to.
         #[cfg_attr(feature = "clap", arg(long))]
+        #[serde(rename = "workspace-id")]
         workspace_id: usize,
     },
 }

--- a/fht-compositor-ipc/src/lib.rs
+++ b/fht-compositor-ipc/src/lib.rs
@@ -52,6 +52,8 @@ pub enum Request {
     Outputs,
     /// Request information about all mapped windows.
     Windows,
+    /// Request information about all layer-shells.
+    LayerShells,
     /// Request information about the workspace system.
     Space,
     /// Request the compositor to execute an action.
@@ -68,6 +70,8 @@ pub enum Response {
     Outputs(HashMap<String, Output>),
     /// All windows information.
     Windows(Vec<Window>),
+    /// All layer-shells information.
+    LayerShells(Vec<LayerShell>),
     /// Space information.
     Space(Space),
     /// There was an error handling the request.
@@ -275,6 +279,48 @@ pub struct Space {
     ///
     /// This should be the monitor that has the pointer cursor in its bounds.
     pub active_idx: usize,
+}
+
+/// A single layer-shell.
+///
+/// A layer-shell represents a component of your desktop interface. They can be for example your
+/// notification popup, a bar, or some fancy widget you created.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct LayerShell {
+    /// The namespace of this layer-shell. It is used to define the purpose of this layer-shell.
+    pub namespace: String,
+    /// The [`Output::name`] this layer-shell is mapped onto.
+    pub output: String,
+    /// The layer this layer-shell is mapped onto.
+    pub layer: Layer,
+    /// The keyboard interactivity of this layer-shell.
+    pub keyboard_interactivity: KeyboardInteractivity,
+}
+
+/// Types of keyboard interaction possible for a layer shell surface.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub enum KeyboardInteractivity {
+    /// No keyboard focus is possible.
+    None = 0,
+    /// The layer-shell requests exclusive keyboard focus.
+    Exclusive,
+    /// The layer-shell requests regular keyboard focus.
+    ///
+    /// This tells the compositor that the layer-surface can accept keyboard input. The user can
+    /// focus the layer-shell by clicking on it.
+    OnDemand,
+}
+
+/// Available layers for surfaces
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub enum Layer {
+    Background = 0,
+    Bottom,
+    Top,
+    Overlay,
 }
 
 /// An action to execute. This enum includes all possible key actions found in

--- a/fht-compositor-ipc/src/lib.rs
+++ b/fht-compositor-ipc/src/lib.rs
@@ -26,6 +26,7 @@ use std::collections::HashMap;
 use std::os::unix::net::UnixStream;
 
 use anyhow::Context;
+use schemars::{schema_for, JsonSchema};
 use serde::{Deserialize, Serialize};
 
 const SOCKET_DEFAULT_ENV: &'static str = "FHTC_SOCKET_PATH";
@@ -42,8 +43,16 @@ pub fn connect() -> anyhow::Result<(std::path::PathBuf, UnixStream)> {
     Ok((socket_path, socket))
 }
 
+/// Print the schema of the [`Request`] type.
+pub fn print_schema() -> anyhow::Result<()> {
+    let schema = schema_for!(Request);
+    let schema_string = serde_json::to_string_pretty(&schema)?;
+    println!("{}", schema_string);
+    Ok(())
+}
+
 /// A request you send to the compositor.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum Request {
     /// Request the version information of the running `fht-compositor` instance.
@@ -82,7 +91,7 @@ pub enum Request {
 }
 
 /// A respose from the compositor.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum Response {
     /// Version information about the running `fht-compositor` instance.
@@ -110,7 +119,7 @@ pub enum Response {
 }
 
 /// A single output.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct Output {
     /// Name of the output.
@@ -138,7 +147,7 @@ pub struct Output {
 }
 
 /// Output mode.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct OutputMode {
     /// The dimensions in physical pixels.
@@ -149,7 +158,7 @@ pub struct OutputMode {
     pub preferred: bool,
 }
 
-#[derive(Default, Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[derive(Default, Debug, Clone, Copy, Serialize, Deserialize, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub enum OutputTransform {
     #[default]
@@ -190,7 +199,7 @@ impl From<smithay::utils::Transform> for OutputTransform {
 ///
 /// A window is a mapped onto the screen inside a [`Workspace`]. A [`Workspace`] is managed inside a
 /// [`Monitor`]. A window can't exist on two workspaces/monitors at the same time.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct Window {
     /// The unique ID of this window. It is used to make requests regarding this specific window.
@@ -238,7 +247,7 @@ pub struct Window {
 /// A single workspace.
 ///
 /// A workspace is a container of windows. It manages them and organizes them.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct Workspace {
     /// The unique ID of this workspace. It is used to make requests regarding this specific
@@ -277,7 +286,7 @@ const WORKSPACE_COUNT: usize = 9;
 ///
 /// A monitor is a representation of an [`Output`] in the [`Workspace`] system. Each monitor is a
 /// view onto a single workspace at a time.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct Monitor {
     /// The output associated with this monitor.
@@ -294,7 +303,7 @@ pub struct Monitor {
 ///
 /// The space is the area containing all [`Monitor`] that organizes and orders them. When something
 /// mentions "global coordinates", it means the *logical* coordinate space inside this space.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct Space {
     /// The [`Monitor`]s tracked by the [`Space`]
@@ -314,7 +323,7 @@ pub struct Space {
 ///
 /// A layer-shell represents a component of your desktop interface. They can be for example your
 /// notification popup, a bar, or some fancy widget you created.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub struct LayerShell {
     /// The namespace of this layer-shell. It is used to define the purpose of this layer-shell.
@@ -328,7 +337,7 @@ pub struct LayerShell {
 }
 
 /// Types of keyboard interaction possible for a layer shell surface.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub enum KeyboardInteractivity {
     /// No keyboard focus is possible.
@@ -343,7 +352,7 @@ pub enum KeyboardInteractivity {
 }
 
 /// Available layers for surfaces
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case", deny_unknown_fields)]
 pub enum Layer {
     Background = 0,
@@ -354,7 +363,7 @@ pub enum Layer {
 
 /// An action to execute. This enum includes all possible key actions found in
 /// fht-compositor-config, and additional ones that are more specific.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 #[cfg_attr(feature = "clap", derive(clap::Parser))]
 #[cfg_attr(feature = "clap", command(subcommand_value_name = "ACTION"))]
 #[cfg_attr(feature = "clap", command(subcommand_help_heading = "Actions"))]
@@ -546,7 +555,7 @@ pub enum Action {
 }
 
 /// A window location change.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, JsonSchema)]
 #[cfg_attr(feature = "clap", derive(clap::Parser))]
 pub enum WindowLocationChange {
     /// Add this amount to the window location.
@@ -566,7 +575,7 @@ pub enum WindowLocationChange {
 }
 
 /// A window size change.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, Eq, JsonSchema)]
 #[cfg_attr(feature = "clap", derive(clap::Parser))]
 pub enum WindowSizeChange {
     /// Add this amount to the current window size. Clamps at (20, 20) for the minimum.
@@ -586,7 +595,7 @@ pub enum WindowSizeChange {
 }
 
 /// A window proportion change.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 #[cfg_attr(feature = "clap", derive(clap::Parser))]
 pub enum WindowProportionChange {
     /// Add this amount to the current window proportion.
@@ -602,7 +611,7 @@ pub enum WindowProportionChange {
 }
 
 /// A master width factor change.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 #[cfg_attr(feature = "clap", derive(clap::Parser))]
 pub enum MwfactChange {
     /// Add this amount to the master width factor. Clamps inside [0.01, 0.99].
@@ -618,7 +627,7 @@ pub enum MwfactChange {
 }
 
 /// A number of master clients change.
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 #[cfg_attr(feature = "clap", derive(clap::Parser))]
 pub enum NmasterChange {
     /// Add this amount to the number of master clients. Clamps at min=1.
@@ -631,7 +640,7 @@ pub enum NmasterChange {
 }
 
 /// The result from picking a [`Window`].
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum PickWindowResult {
     /// The ID of the picked window
@@ -643,7 +652,7 @@ pub enum PickWindowResult {
 }
 
 /// The result from picking a [`LayerShell`].
-#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum PickLayerShellResult {
     /// The information of the picked layer-shell

--- a/fht-compositor-ipc/src/lib.rs
+++ b/fht-compositor-ipc/src/lib.rs
@@ -44,6 +44,7 @@ pub fn connect() -> anyhow::Result<(std::path::PathBuf, UnixStream)> {
 
 /// A request you send to the compositor.
 #[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[cfg_attr(feature = "clap", derive(clap::Subcommand))]
 #[serde(rename_all = "kebab-case")]
 pub enum Request {
     /// Request the version information of the running `fht-compositor` instance.
@@ -209,8 +210,8 @@ pub struct Workspace {
     pub id: usize,
     /// The [`Output`] this workspace belongs to.
     pub output: String,
-    /// The [`Window`] list of this workspace.
-    pub windows: Vec<Window>,
+    /// The [`Window`] IDs on this workspace.
+    pub windows: Vec<usize>,
     /// The active window index.
     ///
     /// If there's a fullscreened window,

--- a/fht-compositor-ipc/src/lib.rs
+++ b/fht-compositor-ipc/src/lib.rs
@@ -22,9 +22,11 @@
 //!
 //! **TODO**: Event stream
 
+use std::collections::HashMap;
 use std::os::unix::net::UnixStream;
 
 use anyhow::Context;
+use serde::{Deserialize, Serialize};
 
 const SOCKET_DEFAULT_ENV: &'static str = "FHTC_SOCKET_PATH";
 
@@ -38,4 +40,101 @@ pub fn connect() -> anyhow::Result<(std::path::PathBuf, UnixStream)> {
     let socket_path = std::path::PathBuf::try_from(socket_path).context("Invalid socket path")?;
     let socket = UnixStream::connect(&socket_path).context("Missing IPC socket")?;
     Ok((socket_path, socket))
+}
+
+/// A request you send to the compositor.
+#[derive(Serialize, Deserialize, Debug, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum Request {
+    /// Request the version information of the running `fht-compositor` instance.
+    Version,
+    /// Request information about the connected outputs.
+    Outputs,
+}
+
+/// A respose from the compositor.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "kebab-case")]
+pub enum Response {
+    /// Version information about the running `fht-compositor` instance.
+    Version(String),
+    /// Output information.
+    Outputs(HashMap<String, Output>),
+}
+
+/// A single output.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct Output {
+    /// Name of the output.
+    pub name: String,
+    /// The output manufacturer.
+    pub make: String,
+    /// The output model.
+    pub model: String,
+    /// Serial of the output, if known.
+    pub serial: Option<String>,
+    /// Physical width and height of the output in mm.
+    pub physical_size: Option<(u32, u32)>,
+    /// Available modes for the output.
+    pub modes: Vec<OutputMode>,
+    /// Active mode index. If `None` there's no modes for this output.
+    pub active_mode_idx: Option<usize>,
+    /// Logical position.
+    pub position: (i32, i32),
+    /// The dimensions in logical pixels
+    pub size: (u32, u32),
+    /// Scale factor.
+    pub scale: i32,
+    /// Transform.
+    pub transform: OutputTransform,
+}
+
+/// Output mode.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct OutputMode {
+    /// The dimensions in physical pixels.
+    pub dimensions: (u32, u32),
+    /// The refresh rate in hertz.
+    pub refresh: f64,
+    /// Whether this mode is the preferred mode.
+    pub preferred: bool,
+}
+
+#[derive(Default, Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub enum OutputTransform {
+    #[default]
+    #[serde(rename = "normal")]
+    Normal,
+    #[serde(rename = "90")]
+    _90,
+    #[serde(rename = "180")]
+    _180,
+    #[serde(rename = "270")]
+    _270,
+    #[serde(rename = "flipped")]
+    Flipped,
+    #[serde(rename = "flipped-90")]
+    Flipped90,
+    #[serde(rename = "flipped-180")]
+    Flipped180,
+    #[serde(rename = "flipped-270")]
+    Flipped270,
+}
+
+impl From<smithay::utils::Transform> for OutputTransform {
+    fn from(value: smithay::utils::Transform) -> Self {
+        match value {
+            smithay::utils::Transform::Normal => OutputTransform::Normal,
+            smithay::utils::Transform::_90 => OutputTransform::_90,
+            smithay::utils::Transform::_180 => OutputTransform::_180,
+            smithay::utils::Transform::_270 => OutputTransform::_270,
+            smithay::utils::Transform::Flipped => OutputTransform::Flipped,
+            smithay::utils::Transform::Flipped90 => OutputTransform::Flipped90,
+            smithay::utils::Transform::Flipped180 => OutputTransform::Flipped180,
+            smithay::utils::Transform::Flipped270 => OutputTransform::Flipped270,
+        }
+    }
 }

--- a/fht-compositor-ipc/src/lib.rs
+++ b/fht-compositor-ipc/src/lib.rs
@@ -1,0 +1,41 @@
+//! Inter-process communication for `fht-compositor`
+//!
+//! ## Interacting with the IPC
+//!
+//! There are three ways to interact the IPC:
+//!
+//! 1. Use the `fht-compositor cli` command line, which is a CLI wrapper around method number 2.
+//!    Useful for writing scripts with the `-j/--json` flag or querying information and have a nice
+//!    (but unstable) output.
+//!
+//! 2. Make programmatic use of the IPC, which gives types to use with [`serde`]. You should open up
+//!    a [`UnixStream`] with [`connect`] and serialize/deserialize your requests to/from JSON.
+//!
+//! 3. Make use of tools like [socat](//www.dest-unreach.org/socat/) with [jq](https://jqlang.org/)
+//!    for more thorough scripting purposes or just use whatever your favourite language has to
+//!    offer for Unix socket communication.
+//!
+//! ## Using the IPC
+//!
+//! When it comes to **using** the IPC, you can query some information using [`Request`] and
+//! get out a [`Response`].
+//!
+//! **TODO**: Event stream
+
+use std::os::unix::net::UnixStream;
+
+use anyhow::Context;
+
+const SOCKET_DEFAULT_ENV: &'static str = "FHTC_SOCKET_PATH";
+
+/// Connect to the `fht-compositor` IPC socket.
+///
+/// You will be responsible to manage this [`UnixStream`], IE. writing [`Request`]s serialized into
+/// JSON using [`serde`] and reading out JSON to deserialize into [`Response`]s.
+pub fn connect() -> anyhow::Result<(std::path::PathBuf, UnixStream)> {
+    let socket_path = std::env::var(SOCKET_DEFAULT_ENV)
+        .context("Missing FHTC_SOCKET_PATH environment variable")?;
+    let socket_path = std::path::PathBuf::try_from(socket_path).context("Invalid socket path")?;
+    let socket = UnixStream::connect(&socket_path).context("Missing IPC socket")?;
+    Ok((socket_path, socket))
+}

--- a/fht-compositor-ipc/src/lib.rs
+++ b/fht-compositor-ipc/src/lib.rs
@@ -60,6 +60,13 @@ pub enum Request {
     Window(usize),
     /// Request information about a workspace.
     Workspace(usize),
+    /// Get a workspace id from an output name and index.
+    GetWorkspace {
+        /// The output name to get the workspace on. If `None`, use the focused output.
+        output: Option<String>,
+        /// The workspace index to get.
+        index: usize,
+    },
     /// Request information about the focused window.
     FocusedWindow,
     /// Request information about the focused workspace.

--- a/fht-compositor-ipc/test_client.rs
+++ b/fht-compositor-ipc/test_client.rs
@@ -9,7 +9,7 @@ fn main() {
     let (_, mut stream) = fht_compositor_ipc::connect().unwrap();
     stream.set_nonblocking(false).unwrap();
 
-    let mut req = serde_json::to_string(&fht_compositor_ipc::Request::Outputs).unwrap();
+    let mut req = serde_json::to_string(&fht_compositor_ipc::Request::Space).unwrap();
     req.push('\n'); // it is required to append a newline.
     let size = stream.write(req.as_bytes()).unwrap();
     assert_eq!(req.len(), size);
@@ -18,6 +18,12 @@ fn main() {
     let size = stream.read_to_string(&mut res_buf).unwrap();
     assert_eq!(res_buf.len(), size);
 
-    let res: Result<fht_compositor_ipc::Response, String> = serde_json::from_str(&res_buf).unwrap();
-    _ = dbg!(res);
+    let Result::<_, String>::Ok(fht_compositor_ipc::Response::Space(space)) =
+        serde_json::de::from_str(&res_buf).unwrap()
+    else {
+        panic!()
+    };
+
+    let windows_json = serde_json::to_string(&space).unwrap();
+    println!("{}", windows_json);
 }

--- a/fht-compositor-ipc/test_client.rs
+++ b/fht-compositor-ipc/test_client.rs
@@ -1,0 +1,23 @@
+use std::io::{Read, Write};
+
+fn main() {
+    let given_path = std::env::args().skip(1).next().unwrap();
+    unsafe {
+        std::env::set_var("FHTC_SOCKET_PATH", given_path);
+    }
+
+    let (_, mut stream) = fht_compositor_ipc::connect().unwrap();
+    stream.set_nonblocking(false).unwrap();
+
+    let mut req = serde_json::to_string(&fht_compositor_ipc::Request::Outputs).unwrap();
+    req.push('\n'); // it is required to append a newline.
+    let size = stream.write(req.as_bytes()).unwrap();
+    assert_eq!(req.len(), size);
+
+    let mut res_buf = String::new();
+    let size = stream.read_to_string(&mut res_buf).unwrap();
+    assert_eq!(res_buf.len(), size);
+
+    let res: Result<fht_compositor_ipc::Response, String> = serde_json::from_str(&res_buf).unwrap();
+    _ = dbg!(res);
+}

--- a/src/backend/headless.rs
+++ b/src/backend/headless.rs
@@ -1,0 +1,74 @@
+use smithay::backend::renderer::element::RenderElementStates;
+use smithay::output::{Mode, Output, PhysicalProperties, Subpixel};
+use smithay::reexports::wayland_protocols::wp::presentation_time::server::wp_presentation_feedback;
+use smithay::utils::Transform;
+
+use crate::output::RedrawState;
+use crate::state::Fht;
+use crate::utils::get_monotonic_time;
+
+pub struct HeadlessData {
+    output: Output,
+}
+
+impl HeadlessData {
+    pub fn new(fht: &mut Fht) -> Self {
+        // Create a dummy output to initiate the workspace system that depends on one.
+        let name = String::from("headless-0");
+        let props = PhysicalProperties {
+            make: String::from("fht-compositor"),
+            model: String::from("headless-output"),
+            size: (0, 0).into(),
+            subpixel: Subpixel::None,
+        };
+        let output = Output::new(name, props);
+        let mode = Mode {
+            refresh: 60_000,
+            size: (1920, 1080).into(),
+        };
+        output.add_mode(mode);
+        output.set_preferred(mode);
+        output.change_current_state(
+            Some(mode),
+            Some(Transform::Normal),
+            Some(smithay::output::Scale::Integer(1)),
+            Some((0, 0).into()),
+        );
+
+        fht.add_output(output.clone(), None);
+
+        Self { output }
+    }
+
+    pub fn render(&mut self, fht: &mut Fht) -> anyhow::Result<bool> {
+        // We are assured that there's only a single output.
+
+        // This pretty much does the same thing as Winit but without:
+        // 1. Creating render elements since there's nowhere to draw them
+        // 2. Damage tracking whatsoever
+        // 3. Buffer submitting
+        // 1. Damage tracking
+        let states = RenderElementStates::default();
+        let mut feedbacks = fht.take_presentation_feedback(&self.output, &states);
+        feedbacks.presented::<_, smithay::utils::Monotonic>(
+            get_monotonic_time(),
+            smithay::wayland::presentation::Refresh::Unknown,
+            0,
+            wp_presentation_feedback::Kind::empty(),
+        );
+
+        let output_state = fht.output_state.get_mut(&self.output).unwrap();
+        output_state.current_frame_sequence = output_state.current_frame_sequence.wrapping_add(1);
+        match std::mem::replace(&mut output_state.redraw_state, RedrawState::Idle) {
+            RedrawState::Queued => (),
+            _ => unreachable!(),
+        }
+
+        if output_state.animations_running {
+            output_state.redraw_state = RedrawState::Queued;
+        }
+
+        // FIXME: Perhaps now always mark this as presented with damage?
+        Ok(true)
+    }
+}

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -5,6 +5,8 @@ use smithay::output::Output;
 
 use crate::state::Fht;
 
+#[cfg(feature = "headless-backend")]
+pub mod headless;
 #[cfg(feature = "udev-backend")]
 pub mod udev;
 #[cfg(feature = "winit-backend")]
@@ -15,6 +17,8 @@ pub enum Backend {
     Winit(winit::WinitData),
     #[cfg(feature = "udev-backend")]
     Udev(udev::UdevData),
+    #[cfg(feature = "headless-backend")]
+    Headless(headless::HeadlessData),
 }
 
 #[cfg(feature = "winit-backend")]
@@ -28,6 +32,13 @@ impl From<winit::WinitData> for Backend {
 impl From<udev::UdevData> for Backend {
     fn from(value: udev::UdevData) -> Self {
         Self::Udev(value)
+    }
+}
+
+#[cfg(feature = "headless-backend")]
+impl From<headless::HeadlessData> for Backend {
+    fn from(value: headless::HeadlessData) -> Self {
+        Self::Headless(value)
     }
 }
 
@@ -59,10 +70,21 @@ impl Backend {
         match self {
             #[cfg(feature = "winit-backend")]
             #[allow(irrefutable_let_patterns)]
-            Self::Winit(data) => data.render(fht),
+            Self::Winit(data) => {
+                _ = output;
+                _ = target_presentation_time;
+                data.render(fht)
+            }
             #[cfg(feature = "udev-backend")]
             #[allow(irrefutable_let_patterns)]
             Self::Udev(data) => data.render(fht, output, target_presentation_time),
+            #[cfg(feature = "headless-backend")]
+            #[allow(irrefutable_let_patterns)]
+            Self::Headless(data) => {
+                _ = target_presentation_time;
+                _ = output;
+                data.render(fht)
+            }
             #[allow(unreachable_patterns)]
             _ => unreachable!(),
         }
@@ -71,11 +93,11 @@ impl Backend {
     pub fn with_renderer<T>(
         &mut self,
         #[allow(unused)] f: impl FnOnce(&mut GlowRenderer) -> T,
-    ) -> T {
+    ) -> Option<T> {
         match self {
             #[cfg(feature = "winit-backend")]
             #[allow(irrefutable_let_patterns)]
-            Self::Winit(ref mut data) => f(data.renderer()),
+            Self::Winit(ref mut data) => Some(f(data.renderer())),
             #[cfg(feature = "udev-backend")]
             #[allow(irrefutable_let_patterns)]
             Self::Udev(data) => {
@@ -84,7 +106,15 @@ impl Backend {
                     .single_renderer(&data.primary_gpu)
                     .expect("No primary gpu");
                 use crate::renderer::AsGlowRenderer;
-                f(renderer.glow_renderer_mut())
+                Some(f(renderer.glow_renderer_mut()))
+            }
+            #[allow(unreachable_patterns)]
+            #[cfg(feature = "headless-backend")]
+            #[allow(irrefutable_let_patterns)]
+            Self::Headless(_) => {
+                // No renderer, nothing todo with the closure
+                let _ = f;
+                None
             }
             #[allow(unreachable_patterns)]
             _ => unreachable!(),
@@ -100,11 +130,24 @@ impl Backend {
         match self {
             #[cfg(feature = "winit-backend")]
             #[allow(irrefutable_let_patterns)]
-            // winit who cares
-            Self::Winit(_) => Ok(()),
+            Self::Winit(_) => {
+                _ = fht;
+                _ = output;
+                _ = mode;
+                Ok(())
+            }
             #[cfg(feature = "udev-backend")]
             #[allow(irrefutable_let_patterns)]
-            Self::Udev(data) => data.set_output_mode(fht, output, mode),
+            #[cfg(feature = "headless-backend")]
+            #[allow(irrefutable_let_patterns)]
+            Self::Headless(_) => {
+                _ = fht;
+                _ = output;
+                _ = mode;
+                Ok(())
+            }
+            #[allow(unreachable_patterns)]
+            _ => unreachable!(),
         }
     }
 }

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -138,6 +138,7 @@ impl Backend {
             }
             #[cfg(feature = "udev-backend")]
             #[allow(irrefutable_let_patterns)]
+            Self::Udev(data) => data.set_output_mode(fht, output, mode),
             #[cfg(feature = "headless-backend")]
             #[allow(irrefutable_let_patterns)]
             Self::Headless(_) => {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -55,6 +55,8 @@ pub enum Request {
     Windows,
     /// Request information about the workspace system.
     Space,
+    /// Request information about all layer-shells.
+    LayerShells,
     /// Request the compositor to execute an action.
     Action {
         #[command(subcommand)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -91,6 +91,9 @@ pub enum Request {
         #[command(subcommand)]
         action: fht_compositor_ipc::Action,
     },
+    /// Print the JSON schema for the IPC [`Request`](fht_compositor_ipc::Request) type. You can
+    /// feed this schema into generators to integrate with other languages.
+    PrintSchema,
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -65,6 +65,15 @@ pub enum Request {
         #[arg(long)]
         id: usize,
     },
+    /// Get a workspace from an output name and index.
+    GetWorkspace {
+        /// The output name to get the workspace on. If not provided, use the focused output.
+        #[arg(long)]
+        output: Option<String>,
+        /// The workspace index to get.
+        #[arg(long)]
+        index: usize,
+    },
     /// Request information about the focused window.
     FocusedWindow,
     /// Request information about the focused workspace.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -49,7 +49,7 @@ pub enum BackendType {
     Headless,
 }
 
-fn get_version_string() -> String {
+pub fn get_version_string() -> String {
     let major = env!("CARGO_PKG_VERSION_MAJOR");
     let minor = env!("CARGO_PKG_VERSION_MINOR");
     let patch = env!("CARGO_PKG_VERSION_PATCH");

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -44,6 +44,9 @@ pub enum BackendType {
     #[cfg(feature = "udev-backend")]
     /// Use the Udev backend, using a libseat session.
     Udev,
+    #[cfg(feature = "headless-backend")]
+    /// Use the headless backend, only meant for testing.
+    Headless,
 }
 
 fn get_version_string() -> String {

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -61,6 +61,12 @@ pub enum Request {
     FocusedWorkspace,
     /// Request information about all layer-shells.
     LayerShells,
+    /// Request the user to pick a window. On the next click, the information of the window under
+    /// the pointer cursor will be sent back.
+    PickWindow,
+    /// Request the user to pick a layer-shell. On the next click, the information of the
+    /// layer-shell under the pointer cursor will be sent back, if any.
+    PickLayerShell,
     /// Request the compositor to execute an action.
     Action {
         #[command(subcommand)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -55,6 +55,10 @@ pub enum Request {
     Windows,
     /// Request information about the workspace system.
     Space,
+    /// Request information about the focused window.
+    FocusedWindow,
+    /// Request information about the focused workspace.
+    FocusedWorkspace,
     /// Request information about all layer-shells.
     LayerShells,
     /// Request the compositor to execute an action.

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -28,7 +28,7 @@ pub struct Cli {
     pub command: Option<Command>,
 }
 
-#[derive(Debug, Clone, Copy, clap::Subcommand)]
+#[derive(Debug, Clone, clap::Subcommand)]
 pub enum Command {
     /// Check the compositor configuration for any errors.
     CheckConfiguration,
@@ -37,10 +37,28 @@ pub enum Command {
     /// Execute an IPC [`Request`].
     Ipc {
         #[command(subcommand)]
-        request: fht_compositor_ipc::Request,
+        request: Request,
         /// Enable JSON output formatting
         #[arg(short, long)]
         json: bool,
+    },
+}
+
+/// A request you send to the compositor.
+#[derive(Debug, Clone, PartialEq, clap::Subcommand)]
+pub enum Request {
+    /// Request the version information of the running `fht-compositor` instance.
+    Version,
+    /// Request information about the connected outputs.
+    Outputs,
+    /// Request information about all mapped windows.
+    Windows,
+    /// Request information about the workspace system.
+    Space,
+    /// Request the compositor to execute an action.
+    Action {
+        #[command(subcommand)]
+        action: fht_compositor_ipc::Action,
     },
 }
 

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -34,6 +34,14 @@ pub enum Command {
     CheckConfiguration,
     /// Generate shell completions for shell
     GenerateCompletions { shell: clap_complete::Shell },
+    /// Execute an IPC [`Request`].
+    Ipc {
+        #[command(subcommand)]
+        request: fht_compositor_ipc::Request,
+        /// Enable JSON output formatting
+        #[arg(short, long)]
+        json: bool,
+    },
 }
 
 #[derive(Debug, Clone, Copy, clap::ValueEnum)]

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -55,6 +55,16 @@ pub enum Request {
     Windows,
     /// Request information about the workspace system.
     Space,
+    /// Request information about a window.
+    Window {
+        #[arg(long)]
+        id: usize,
+    },
+    /// Request information about a workspace.
+    Workspace {
+        #[arg(long)]
+        id: usize,
+    },
     /// Request information about the focused window.
     FocusedWindow,
     /// Request information about the focused workspace.

--- a/src/handlers/dmabuf.rs
+++ b/src/handlers/dmabuf.rs
@@ -22,6 +22,11 @@ impl DmabufHandler for State {
             #[cfg(feature = "udev-backend")]
             #[allow(irrefutable_let_patterns)]
             crate::backend::Backend::Udev(ref mut data) => data.dmabuf_imported(dmabuf, notifier),
+            #[cfg(feature = "headless-backend")]
+            #[allow(irrefutable_let_patterns)]
+            crate::backend::Backend::Headless(_) => {
+                let _ = notifier.successful::<State>();
+            }
             _ => unreachable!(),
         };
     }

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -53,11 +53,11 @@ pub enum KeyActionType {
 #[derive(Debug, Clone)]
 pub struct KeyAction {
     /// The type of the [`KeyAction`], I.E what to do.
-    r#type: KeyActionType,
+    pub r#type: KeyActionType,
     /// Whether we should allow this [`KeyAction`] to be executed while the compositor is locked.
-    allow_while_locked: bool,
+    pub allow_while_locked: bool,
     /// Whether we should repeat this key binding.
-    repeat: bool,
+    pub repeat: bool,
 }
 
 impl KeyAction {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -1,4 +1,5 @@
 pub mod actions;
+pub mod pick_surface_grab;
 pub mod resize_tile_grab;
 pub mod swap_tile_grab;
 
@@ -49,7 +50,6 @@ impl State {
 
         let output = &self.fht.space.active_output().clone();
         let output_loc = output.current_location();
-
         let pointer_loc = pointer.current_location();
 
         if self.fht.is_locked() {

--- a/src/input/pick_surface_grab.rs
+++ b/src/input/pick_surface_grab.rs
@@ -1,0 +1,294 @@
+//! A grab to pick a window/layer surface.
+
+use async_channel::Sender;
+use fht_compositor_ipc::{PickLayerShellResult, PickWindowResult};
+use smithay::backend::input::ButtonState;
+use smithay::desktop::{layer_map_for_output, LayerSurface, WindowSurfaceType};
+use smithay::input::pointer::{ButtonEvent, GrabStartData, PointerGrab, PointerInnerHandle};
+use smithay::wayland::shell::wlr_layer::Layer;
+
+use crate::state::State;
+
+pub struct PickSurfaceGrab {
+    pub target: PickSurfaceTarget,
+    pub start_data: GrabStartData<State>,
+}
+
+pub enum PickSurfaceTarget {
+    Window(Sender<PickWindowResult>),
+    LayerSurface(Sender<PickLayerShellResult>),
+}
+
+impl PickSurfaceTarget {
+    #[allow(clippy::type_complexity)]
+    fn picked_window(&mut self, window_id: usize) {
+        match self {
+            PickSurfaceTarget::Window(sender) => {
+                _ = sender.try_send(PickWindowResult::Some(window_id));
+            }
+            PickSurfaceTarget::LayerSurface(sender) => {
+                _ = sender.try_send(PickLayerShellResult::None);
+            }
+        }
+    }
+
+    fn picked_layer_surface(&mut self, layer_surface: &LayerSurface, output: String) {
+        let ipc_layer = fht_compositor_ipc::LayerShell {
+            namespace: layer_surface.namespace().to_string(),
+            output,
+            // SAFETY: We know that all the enum variants are the same
+            layer: unsafe { std::mem::transmute(layer_surface.layer()) },
+            keyboard_interactivity: unsafe {
+                std::mem::transmute(layer_surface.cached_state().keyboard_interactivity)
+            },
+        };
+
+        match self {
+            PickSurfaceTarget::Window(sender) => {
+                _ = sender.try_send(PickWindowResult::None);
+            }
+            PickSurfaceTarget::LayerSurface(sender) => {
+                _ = sender.try_send(PickLayerShellResult::Some(ipc_layer));
+            }
+        }
+    }
+
+    pub fn cancel(&mut self) {
+        // NOTE: Use try_send since we might have used the sender by now, so the channel is now full
+        // and the IPC client would have dropped the received by then.
+        match self {
+            PickSurfaceTarget::Window(sender) => {
+                _ = sender.try_send(PickWindowResult::Cancelled);
+            }
+            PickSurfaceTarget::LayerSurface(sender) => {
+                _ = sender.try_send(PickLayerShellResult::Cancelled);
+            }
+        }
+    }
+}
+
+impl PointerGrab<State> for PickSurfaceGrab {
+    fn motion(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        focus: Option<(
+            <State as smithay::input::SeatHandler>::PointerFocus,
+            smithay::utils::Point<f64, smithay::utils::Logical>,
+        )>,
+        event: &smithay::input::pointer::MotionEvent,
+    ) {
+        handle.motion(data, focus, event);
+    }
+
+    fn relative_motion(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        focus: Option<(
+            <State as smithay::input::SeatHandler>::PointerFocus,
+            smithay::utils::Point<f64, smithay::utils::Logical>,
+        )>,
+        event: &smithay::input::pointer::RelativeMotionEvent,
+    ) {
+        handle.relative_motion(data, focus, event);
+    }
+
+    fn button(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        event: &ButtonEvent,
+    ) {
+        const BTN_LEFT: u32 = 0x110;
+        if event.button != BTN_LEFT || event.state != ButtonState::Pressed {
+            // Pass all events as normal, we only care about left clicks.
+            handle.button(data, event);
+            return;
+        }
+
+        if data.fht.is_locked() {
+            // Do not allow information to leak when locked
+            handle.unset_grab(self, data, event.serial, event.time, true);
+            return;
+        }
+
+        let mut tile_under = None;
+        let mut layer_under = None;
+
+        // NOTE: Keep this logic up-to-date with State::update_keyboard_focus to avoid inconsistency
+        // between whats being picked and whats being focused.
+        //
+        // NOTE: For layer-shells we dont check for keyboard interactivity since its pointless to
+        // filter based on that for picking layer-shells
+
+        let output = &data.fht.space.active_output().clone();
+        let output_loc = output.current_location();
+        let pointer_loc = handle.current_location();
+
+        let layer_map = layer_map_for_output(output);
+        let monitor = data
+            .fht
+            .space
+            .monitor_for_output(output)
+            .expect("focused output should always have a monitor");
+
+        if let Some(layer) = layer_map.layer_under(Layer::Overlay, pointer_loc) {
+            let layer_loc = layer_map.layer_geometry(layer).unwrap().loc;
+            if layer
+                .surface_under(
+                    pointer_loc - output_loc.to_f64() - layer_loc.to_f64(),
+                    WindowSurfaceType::ALL,
+                )
+                .is_some()
+            {
+                layer_under = Some((layer.clone(), output.name()));
+            }
+        } else if let Some(fullscreen) = monitor.active_workspace().fullscreened_tile() {
+            // Fullscreen focus is always exclusive
+            if fullscreen
+                .window()
+                .surface_under(pointer_loc - output_loc.to_f64(), WindowSurfaceType::ALL)
+                .is_some()
+            {
+                tile_under = Some(fullscreen.window().id());
+            }
+        } else if let Some(layer) = layer_map.layer_under(Layer::Top, pointer_loc) {
+            let layer_loc = layer_map.layer_geometry(layer).unwrap().loc;
+            if layer
+                .surface_under(
+                    pointer_loc - output_loc.to_f64() - layer_loc.to_f64(),
+                    WindowSurfaceType::ALL,
+                )
+                .is_some()
+            {
+                layer_under = Some((layer.clone(), output.name()));
+            }
+        } else if let Some((window, _)) = data.fht.space.window_under(pointer_loc) {
+            tile_under = Some(window.id());
+        } else if let Some(layer) = layer_map
+            .layer_under(Layer::Bottom, pointer_loc)
+            .or_else(|| layer_map.layer_under(Layer::Background, pointer_loc))
+        {
+            let layer_loc = layer_map.layer_geometry(layer).unwrap().loc;
+            if layer
+                .surface_under(
+                    pointer_loc - output_loc.to_f64() - layer_loc.to_f64(),
+                    WindowSurfaceType::ALL,
+                )
+                .is_some()
+            {
+                layer_under = Some((layer.clone(), output.name()));
+            }
+        }
+
+        assert!(
+            tile_under.is_none() || layer_under.is_none(),
+            "picked both a window AND a layer-shell"
+        );
+
+        if let Some(id) = tile_under {
+            self.target.picked_window(*id);
+        }
+
+        if let Some((layer, output)) = layer_under {
+            self.target.picked_layer_surface(&layer, output);
+        }
+
+        // And we dont make the button event go through, though we remove the grab.
+        handle.unset_grab(self, data, event.serial, event.time, true);
+    }
+
+    fn axis(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        details: smithay::input::pointer::AxisFrame,
+    ) {
+        handle.axis(data, details);
+    }
+
+    fn frame(&mut self, data: &mut State, handle: &mut PointerInnerHandle<'_, State>) {
+        handle.frame(data);
+    }
+
+    fn gesture_swipe_begin(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        event: &smithay::input::pointer::GestureSwipeBeginEvent,
+    ) {
+        handle.gesture_swipe_begin(data, event);
+    }
+
+    fn gesture_swipe_update(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        event: &smithay::input::pointer::GestureSwipeUpdateEvent,
+    ) {
+        handle.gesture_swipe_update(data, event);
+    }
+
+    fn gesture_swipe_end(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        event: &smithay::input::pointer::GestureSwipeEndEvent,
+    ) {
+        handle.gesture_swipe_end(data, event);
+    }
+
+    fn gesture_pinch_begin(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        event: &smithay::input::pointer::GesturePinchBeginEvent,
+    ) {
+        handle.gesture_pinch_begin(data, event);
+    }
+
+    fn gesture_pinch_update(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        event: &smithay::input::pointer::GesturePinchUpdateEvent,
+    ) {
+        handle.gesture_pinch_update(data, event);
+    }
+
+    fn gesture_pinch_end(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        event: &smithay::input::pointer::GesturePinchEndEvent,
+    ) {
+        handle.gesture_pinch_end(data, event);
+    }
+
+    fn gesture_hold_begin(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        event: &smithay::input::pointer::GestureHoldBeginEvent,
+    ) {
+        handle.gesture_hold_begin(data, event);
+    }
+
+    fn gesture_hold_end(
+        &mut self,
+        data: &mut State,
+        handle: &mut PointerInnerHandle<'_, State>,
+        event: &smithay::input::pointer::GestureHoldEndEvent,
+    ) {
+        handle.gesture_hold_end(data, event);
+    }
+
+    fn start_data(&self) -> &GrabStartData<State> {
+        &self.start_data
+    }
+
+    fn unset(&mut self, _: &mut State) {
+        self.target.cancel();
+    }
+}

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -1,0 +1,161 @@
+use std::io::{Read, Write as _};
+
+/// Make a single request to the running `fht-compositor` IPC server.
+///
+/// It uses the IPC socket specified by the `FHTC_SOCKET_PATH` environment variable.
+pub fn make_request(request: fht_compositor_ipc::Request, json: bool) -> anyhow::Result<()> {
+    // This is just a re-implementation of fht-compositor-ipc/test_client with cleaner error
+    // handling for error logging yada-yada
+
+    let (_, mut stream) = fht_compositor_ipc::connect()?;
+    stream.set_nonblocking(false)?;
+
+    let mut req = serde_json::to_string(&request).unwrap();
+    req.push('\n'); // it is required to append a newline.
+    let size = stream.write(req.as_bytes()).unwrap();
+    anyhow::ensure!(req.len() == size);
+
+    let mut res_buf = String::new();
+    let size = stream.read_to_string(&mut res_buf).unwrap();
+    anyhow::ensure!(res_buf.len() == size);
+
+    let response: Result<fht_compositor_ipc::Response, String> =
+        serde_json::de::from_str(&res_buf)?;
+    let response = match response {
+        Ok(res) => res,
+        Err(err) => anyhow::bail!("IPC error: {err}"),
+    };
+
+    if json {
+        let json_buffer = serde_json::to_string(&response)?;
+        println!("{}", json_buffer);
+        Ok(())
+    } else {
+        print_formatted(&response)?;
+        Ok(())
+    }
+}
+
+fn print_formatted(res: &fht_compositor_ipc::Response) -> std::io::Result<()> {
+    let mut writer = std::io::BufWriter::new(std::io::stdout());
+    match res {
+        fht_compositor_ipc::Response::Version(version) => println!("{version}"),
+        fht_compositor_ipc::Response::Outputs(outputs) => {
+            for (idx, output) in outputs.values().enumerate() {
+                writeln!(&mut writer, "Output #{idx}: {}", output.name)?;
+                writeln!(&mut writer, "\tName: {}", output.name)?;
+                writeln!(&mut writer, "\tMake: {}", output.make)?;
+                writeln!(&mut writer, "\tModel: {}", output.model)?;
+                writeln!(&mut writer, "\tSerial: {:?}", output.serial)?;
+                writeln!(
+                    &mut writer,
+                    "\tPhysical size (mm): {}",
+                    if let Some((w, h)) = output.physical_size {
+                        format!("({w}, {h})")
+                    } else {
+                        String::from("unknown")
+                    }
+                )?;
+                writeln!(
+                    &mut writer,
+                    "\tLogical Position: ({}, {})",
+                    output.position.0, output.position.1
+                )?;
+                writeln!(
+                    &mut writer,
+                    "\tSize (px): ({}, {})",
+                    output.size.0, output.size.1
+                )?;
+                writeln!(&mut writer, "\tScale: {}", output.scale)?;
+                writeln!(&mut writer, "\tTransform: {:?}", output.transform)?;
+
+                // Modes
+                writeln!(&mut writer, "\tModes:")?;
+                for (mode_idx, mode) in output.modes.iter().enumerate() {
+                    let mut mode_buffer = String::new();
+                    mode_buffer.push_str(&format!(
+                        "{}x{}@{}",
+                        mode.dimensions.0, mode.dimensions.1, mode.refresh
+                    ));
+                    if mode.preferred {
+                        mode_buffer.push_str(" preferred");
+                    }
+                    if Some(mode_idx) == output.active_mode_idx {
+                        mode_buffer.push_str(" active");
+                    }
+
+                    writeln!(&mut writer, "\t\t{mode_buffer}")?;
+                }
+                writeln!(&mut writer, "---")?;
+            }
+        }
+        fht_compositor_ipc::Response::Windows(windows) => {
+            for window in windows {
+                writeln!(&mut writer, "Window #{}", window.id)?;
+                writeln!(&mut writer, "\tTitle: {:?}", window.title)?;
+                writeln!(&mut writer, "\tApplication ID: {:?}", window.app_id)?;
+                writeln!(&mut writer, "\tCurrent output: {}", window.output)?;
+                writeln!(
+                    &mut writer,
+                    "\tCurrent workspace index: {}",
+                    window.workspace_idx
+                )?;
+                writeln!(
+                    &mut writer,
+                    "\tCurrent workspace ID: {}",
+                    window.workspace_id
+                )?;
+                writeln!(
+                    &mut writer,
+                    "\tSize: ({}, {})",
+                    window.size.0, window.size.1
+                )?;
+                writeln!(
+                    &mut writer,
+                    "\tLocation: ({}, {})",
+                    window.location.0, window.location.1
+                )?;
+                writeln!(&mut writer, "\tFullscreened: {}", window.fullscreened)?;
+                writeln!(&mut writer, "\tMaximized: {}", window.maximized)?;
+                writeln!(&mut writer, "\tTiled: {}", window.tiled)?;
+                writeln!(&mut writer, "\tActivated: {}", window.activated)?;
+                writeln!(&mut writer, "\tFocused: {}", window.focused)?;
+                writeln!(&mut writer, "---")?;
+            }
+        }
+        fht_compositor_ipc::Response::Space(fht_compositor_ipc::Space {
+            monitors,
+            primary_idx,
+            active_idx,
+        }) => {
+            writeln!(&mut writer, "Space")?;
+            for (idx, monitor) in monitors.iter().enumerate() {
+                writeln!(&mut writer, "\tMonitor #{idx}:")?;
+                writeln!(&mut writer, "\t\tOutput: {}", monitor.output)?;
+                writeln!(&mut writer, "\t\tPrimary: {}", idx == *primary_idx)?;
+                writeln!(&mut writer, "\t\tActive: {}", idx == *active_idx)?;
+                writeln!(&mut writer, "\t\t---")?;
+                for (workspace_idx, workspace) in monitor.workspaces.iter().enumerate() {
+                    writeln!(&mut writer, "\t\tWorkspace #{workspace_idx}:")?;
+                    writeln!(&mut writer, "\t\t\tID: {}", workspace.id)?;
+                    writeln!(&mut writer, "\t\t\tWindows: {:?}", workspace.windows)?;
+                    writeln!(
+                        &mut writer,
+                        "\t\t\tMaster width factor: {}",
+                        workspace.mwfact
+                    )?;
+                    writeln!(
+                        &mut writer,
+                        "\t\t\tNumber of master windows: {}",
+                        workspace.nmaster
+                    )?;
+                    writeln!(&mut writer, "\t\t---")?;
+                }
+            }
+            //
+        }
+        fht_compositor_ipc::Response::Noop => (),
+    }
+
+    Ok(())
+}

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -15,6 +15,9 @@ pub fn make_request(request: cli::Request, json: bool) -> anyhow::Result<()> {
         cli::Request::Space => fht_compositor_ipc::Request::Space,
         cli::Request::Window { id } => fht_compositor_ipc::Request::Window(id),
         cli::Request::Workspace { id } => fht_compositor_ipc::Request::Workspace(id),
+        cli::Request::GetWorkspace { output, index } => {
+            fht_compositor_ipc::Request::GetWorkspace { output, index }
+        }
         cli::Request::LayerShells => fht_compositor_ipc::Request::LayerShells,
         cli::Request::FocusedWindow => fht_compositor_ipc::Request::FocusedWindow,
         cli::Request::FocusedWorkspace => fht_compositor_ipc::Request::FocusedWorkspace,

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -11,6 +11,8 @@ pub fn make_request(request: cli::Request, json: bool) -> anyhow::Result<()> {
         cli::Request::Outputs => fht_compositor_ipc::Request::Outputs,
         cli::Request::Windows => fht_compositor_ipc::Request::Windows,
         cli::Request::LayerShells => fht_compositor_ipc::Request::LayerShells,
+        cli::Request::FocusedWindow => fht_compositor_ipc::Request::FocusedWindow,
+        cli::Request::FocusedWorkspace => fht_compositor_ipc::Request::FocusedWorkspace,
         cli::Request::Space => fht_compositor_ipc::Request::Space,
         cli::Request::Action { action } => fht_compositor_ipc::Request::Action(action),
     };
@@ -43,6 +45,10 @@ pub fn make_request(request: cli::Request, json: bool) -> anyhow::Result<()> {
             fht_compositor_ipc::Response::Windows(windows) => serde_json::to_string(&windows),
             fht_compositor_ipc::Response::LayerShells(layer_shells) => {
                 serde_json::to_string(&layer_shells)
+            }
+            fht_compositor_ipc::Response::FocusedWindow(window) => serde_json::to_string(&window),
+            fht_compositor_ipc::Response::FocusedWorkspace(workspace) => {
+                serde_json::to_string(&workspace)
             }
             fht_compositor_ipc::Response::Space(space) => serde_json::to_string(&space),
             fht_compositor_ipc::Response::Error(err) => {
@@ -113,35 +119,7 @@ fn print_formatted(res: &fht_compositor_ipc::Response) -> anyhow::Result<()> {
         }
         fht_compositor_ipc::Response::Windows(windows) => {
             for window in windows {
-                writeln!(&mut writer, "Window #{}", window.id)?;
-                writeln!(&mut writer, "\tTitle: {:?}", window.title)?;
-                writeln!(&mut writer, "\tApplication ID: {:?}", window.app_id)?;
-                writeln!(&mut writer, "\tCurrent output: {}", window.output)?;
-                writeln!(
-                    &mut writer,
-                    "\tCurrent workspace index: {}",
-                    window.workspace_idx
-                )?;
-                writeln!(
-                    &mut writer,
-                    "\tCurrent workspace ID: {}",
-                    window.workspace_id
-                )?;
-                writeln!(
-                    &mut writer,
-                    "\tSize: ({}, {})",
-                    window.size.0, window.size.1
-                )?;
-                writeln!(
-                    &mut writer,
-                    "\tLocation: ({}, {})",
-                    window.location.0, window.location.1
-                )?;
-                writeln!(&mut writer, "\tFullscreened: {}", window.fullscreened)?;
-                writeln!(&mut writer, "\tMaximized: {}", window.maximized)?;
-                writeln!(&mut writer, "\tTiled: {}", window.tiled)?;
-                writeln!(&mut writer, "\tActivated: {}", window.activated)?;
-                writeln!(&mut writer, "\tFocused: {}", window.focused)?;
+                print_window(&mut writer, window)?;
                 writeln!(&mut writer, "---")?;
             }
         }
@@ -190,9 +168,51 @@ fn print_formatted(res: &fht_compositor_ipc::Response) -> anyhow::Result<()> {
             }
             //
         }
+        fht_compositor_ipc::Response::FocusedWindow(window) => match window.as_ref() {
+            Some(window) => print_window(&mut writer, window)?,
+            None => println!("No focused window"),
+        },
+        fht_compositor_ipc::Response::FocusedWorkspace(workspace) => {
+            writeln!(&mut writer, "ID: {}", workspace.id)?;
+            writeln!(&mut writer, "Windows: {:?}", workspace.windows)?;
+            writeln!(&mut writer, "Master width factor: {}", workspace.mwfact)?;
+            writeln!(
+                &mut writer,
+                "Number of master windows: {}",
+                workspace.nmaster
+            )?;
+        }
         fht_compositor_ipc::Response::Error(err) => anyhow::bail!(err.clone()),
         fht_compositor_ipc::Response::Noop => (),
     }
 
+    Ok(())
+}
+
+fn print_window(
+    writer: &mut impl std::io::Write,
+    window: &fht_compositor_ipc::Window,
+) -> std::io::Result<()> {
+    writeln!(writer, "Window #{}", window.id)?;
+    writeln!(writer, "\tTitle: {:?}", window.title)?;
+    writeln!(writer, "\tApplication ID: {:?}", window.app_id)?;
+    writeln!(writer, "\tCurrent output: {}", window.output)?;
+    writeln!(
+        writer,
+        "\tCurrent workspace index: {}",
+        window.workspace_idx
+    )?;
+    writeln!(writer, "\tCurrent workspace ID: {}", window.workspace_id)?;
+    writeln!(writer, "\tSize: ({}, {})", window.size.0, window.size.1)?;
+    writeln!(
+        writer,
+        "\tLocation: ({}, {})",
+        window.location.0, window.location.1
+    )?;
+    writeln!(writer, "\tFullscreened: {}", window.fullscreened)?;
+    writeln!(writer, "\tMaximized: {}", window.maximized)?;
+    writeln!(writer, "\tTiled: {}", window.tiled)?;
+    writeln!(writer, "\tActivated: {}", window.activated)?;
+    writeln!(writer, "\tFocused: {}", window.focused)?;
     Ok(())
 }

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -198,7 +198,7 @@ fn print_formatted(res: &fht_compositor_ipc::Response) -> anyhow::Result<()> {
         },
         fht_compositor_ipc::Response::Workspace(workspace) => {
             let Some(workspace) = workspace else {
-                writeln!(&mut writer, "No workspace with given ID!");
+                writeln!(&mut writer, "No workspace with given ID!")?;
                 return Ok(());
             };
 

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -46,7 +46,12 @@ pub fn make_request(request: cli::Request, json: bool) -> anyhow::Result<()> {
 
     if json {
         let json_buffer = match response {
-            fht_compositor_ipc::Response::Version(version) => serde_json::to_string(&version),
+            fht_compositor_ipc::Response::Version(version) => {
+                serde_json::to_string(&serde_json::json!({
+                    "compositor": version,
+                    "cli": crate::cli::get_version_string(),
+                }))
+            }
             fht_compositor_ipc::Response::Outputs(hash_map) => serde_json::to_string(&hash_map),
             fht_compositor_ipc::Response::Windows(windows) => serde_json::to_string(&windows),
             fht_compositor_ipc::Response::LayerShells(layer_shells) => {
@@ -90,7 +95,10 @@ pub fn make_request(request: cli::Request, json: bool) -> anyhow::Result<()> {
 fn print_formatted(res: &fht_compositor_ipc::Response) -> anyhow::Result<()> {
     let mut writer = std::io::BufWriter::new(std::io::stdout());
     match res {
-        fht_compositor_ipc::Response::Version(version) => println!("{version}"),
+        fht_compositor_ipc::Response::Version(version) => {
+            println!("Compositor: {version}");
+            println!("CLI: {}", crate::cli::get_version_string())
+        }
         fht_compositor_ipc::Response::Outputs(outputs) => {
             for (idx, output) in outputs.values().enumerate() {
                 writeln!(&mut writer, "Output #{idx}: {}", output.name)?;

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -24,6 +24,7 @@ pub fn make_request(request: cli::Request, json: bool) -> anyhow::Result<()> {
         cli::Request::PickLayerShell => fht_compositor_ipc::Request::PickLayerShell,
         cli::Request::PickWindow => fht_compositor_ipc::Request::PickWindow,
         cli::Request::Action { action } => fht_compositor_ipc::Request::Action(action),
+        cli::Request::PrintSchema => return fht_compositor_ipc::print_schema(),
     };
 
     // This is just a re-implementation of fht-compositor-ipc/test_client with cleaner error

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -10,6 +10,7 @@ pub fn make_request(request: cli::Request, json: bool) -> anyhow::Result<()> {
         cli::Request::Version => fht_compositor_ipc::Request::Version,
         cli::Request::Outputs => fht_compositor_ipc::Request::Outputs,
         cli::Request::Windows => fht_compositor_ipc::Request::Windows,
+        cli::Request::LayerShells => fht_compositor_ipc::Request::LayerShells,
         cli::Request::Space => fht_compositor_ipc::Request::Space,
         cli::Request::Action { action } => fht_compositor_ipc::Request::Action(action),
     };
@@ -40,6 +41,9 @@ pub fn make_request(request: cli::Request, json: bool) -> anyhow::Result<()> {
             fht_compositor_ipc::Response::Version(version) => serde_json::to_string(&version),
             fht_compositor_ipc::Response::Outputs(hash_map) => serde_json::to_string(&hash_map),
             fht_compositor_ipc::Response::Windows(windows) => serde_json::to_string(&windows),
+            fht_compositor_ipc::Response::LayerShells(layer_shells) => {
+                serde_json::to_string(&layer_shells)
+            }
             fht_compositor_ipc::Response::Space(space) => serde_json::to_string(&space),
             fht_compositor_ipc::Response::Error(err) => {
                 anyhow::bail!("Failed to handle IPC request: {err:?}")
@@ -138,6 +142,20 @@ fn print_formatted(res: &fht_compositor_ipc::Response) -> anyhow::Result<()> {
                 writeln!(&mut writer, "\tTiled: {}", window.tiled)?;
                 writeln!(&mut writer, "\tActivated: {}", window.activated)?;
                 writeln!(&mut writer, "\tFocused: {}", window.focused)?;
+                writeln!(&mut writer, "---")?;
+            }
+        }
+        fht_compositor_ipc::Response::LayerShells(layer_shells) => {
+            for (idx, layer_shell) in layer_shells.iter().enumerate() {
+                writeln!(&mut writer, "Layer Shell #{idx}")?;
+                writeln!(&mut writer, "\tOutput: {}", layer_shell.output)?;
+                writeln!(&mut writer, "\tNamespace: {}", layer_shell.namespace)?;
+                writeln!(&mut writer, "\tLayer: {:?}", layer_shell.layer)?;
+                writeln!(
+                    &mut writer,
+                    "\tKeyboard Interactivity: {:?}",
+                    layer_shell.keyboard_interactivity
+                )?;
                 writeln!(&mut writer, "---")?;
             }
         }

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -27,7 +27,13 @@ pub fn make_request(request: fht_compositor_ipc::Request, json: bool) -> anyhow:
     };
 
     if json {
-        let json_buffer = serde_json::to_string(&response)?;
+        let json_buffer = match response {
+            fht_compositor_ipc::Response::Version(version) => serde_json::to_string(&version),
+            fht_compositor_ipc::Response::Outputs(hash_map) => serde_json::to_string(&hash_map),
+            fht_compositor_ipc::Response::Windows(windows) => serde_json::to_string(&windows),
+            fht_compositor_ipc::Response::Space(space) => serde_json::to_string(&space),
+            fht_compositor_ipc::Response::Noop => return Ok(()),
+        }?;
         println!("{}", json_buffer);
         Ok(())
     } else {

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -15,6 +15,9 @@ use crate::focus_target::KeyboardFocusTarget;
 use crate::output::OutputExt;
 use crate::space::Workspace;
 use crate::state::State;
+use crate::window::Window;
+
+pub mod client;
 
 /// The compositor IPC server.
 pub struct Server {
@@ -271,7 +274,6 @@ impl State {
                 tx.send_blocking(windows)?;
             }
             ClientRequest::Space(tx) => {
-                let keyboard_focus = self.fht.keyboard.current_focus();
                 let monitors = self
                     .fht
                     .space
@@ -290,7 +292,11 @@ impl State {
                                     fullscreen_window_idx: workspace.fullscreened_tile_idx(),
                                     mwfact: workspace.mwfact(),
                                     nmaster: workspace.nmaster(),
-                                    windows: workspace_windows(workspace, keyboard_focus.as_ref()),
+                                    windows: workspace
+                                        .windows()
+                                        .map(Window::id)
+                                        .map(|id| *id)
+                                        .collect(),
                                 }
                             })
                             .collect::<Vec<_>>()

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -1,0 +1,56 @@
+use std::io;
+use std::os::unix::net::UnixListener;
+
+use smithay::reexports::calloop::generic::Generic;
+use smithay::reexports::calloop::{Interest, LoopHandle, Mode, PostAction, RegistrationToken};
+
+use crate::state::State;
+
+/// The compositor IPC server.
+pub struct Server {
+    registration_token: RegistrationToken,
+}
+
+/// Start the [`IpcServer`] for the compositor.
+pub fn start(
+    loop_handle: &LoopHandle<'static, State>,
+    wayland_socket_name: &str,
+) -> anyhow::Result<Server> {
+    let pid = std::process::id();
+
+    // SAFETY: We place socket in XDG_RUNTIME_DIR, which should always be available to create the
+    // wayland socket itself.
+    let socket_dir = xdg::BaseDirectories::new()
+        .unwrap()
+        .get_runtime_directory()
+        .cloned()
+        .unwrap();
+    let socket_name = format!("fhtc-{pid}-{wayland_socket_name}.socket");
+    let socket_path = socket_dir.join(&socket_name);
+    let listener = UnixListener::bind(&socket_path)?;
+    listener.set_nonblocking(true)?;
+
+    let generic = Generic::new(listener, Interest::READ, Mode::Level);
+    let registration_token = loop_handle.insert_source(generic, |_, listener, state| {
+        match listener.accept() {
+            Ok((_stream, addr)) => {
+                info!(?addr, "New IPC client");
+                // TODO: Handle clients
+            }
+            Err(err) if err.kind() == io::ErrorKind::WouldBlock => (),
+            Err(err) => return Err(err),
+        }
+
+        // TODO: Handle clients
+        Ok(PostAction::Continue)
+    })?;
+
+    unsafe {
+        // SAFETY: We do not have any threaded activity **yet**
+        std::env::set_var("FHTC_SOCKET_PATH", &socket_path);
+    }
+
+    info!(?socket_path, "Started IPC");
+
+    Ok(Server { registration_token })
+}

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -20,7 +20,7 @@ use crate::focus_target::KeyboardFocusTarget;
 use crate::input::pick_surface_grab::{PickSurfaceGrab, PickSurfaceTarget};
 use crate::input::KeyAction;
 use crate::output::OutputExt;
-use crate::space::{self, Workspace, WorkspaceId};
+use crate::space::{Workspace, WorkspaceId};
 use crate::state::State;
 use crate::utils::get_credentials_for_surface;
 use crate::window::{Window, WindowId};
@@ -32,8 +32,6 @@ pub struct Server {
     // The UnixSocket server that receives incoming clients
     listener_token: RegistrationToken,
     dispatcher: Dispatcher<'static, Generic<UnixListener>, State>,
-    // The calloop channel sender to communicate from/to the compositor.
-    to_compositor: calloop::channel::Sender<ClientRequest>,
 }
 
 impl Server {
@@ -124,7 +122,6 @@ pub fn start(
     Ok(Server {
         dispatcher,
         listener_token: token,
-        to_compositor,
     })
 }
 

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -1,14 +1,33 @@
+use std::collections::HashMap;
 use std::io;
-use std::os::unix::net::UnixListener;
+use std::os::unix::net::{UnixListener, UnixStream};
 
+use calloop::io::Async;
+use fht_compositor_ipc::Response;
+use futures_util::{AsyncBufReadExt, AsyncReadExt, AsyncWriteExt};
 use smithay::reexports::calloop::generic::Generic;
-use smithay::reexports::calloop::{Interest, LoopHandle, Mode, PostAction, RegistrationToken};
+use smithay::reexports::calloop::{
+    Dispatcher, Interest, LoopHandle, Mode, PostAction, RegistrationToken,
+};
 
+use crate::output::OutputExt;
 use crate::state::State;
 
 /// The compositor IPC server.
 pub struct Server {
-    registration_token: RegistrationToken,
+    // The UnixSocket server that receives incoming clients
+    listener_token: RegistrationToken,
+    dispatcher: Dispatcher<'static, Generic<UnixListener>, State>,
+    // The calloop channel sender to communicate from/to the compositor.
+    to_compositor: calloop::channel::Sender<ClientRequest>,
+}
+
+impl Server {
+    pub fn close(self, loop_handle: &LoopHandle<'static, State>) {
+        loop_handle.remove(self.listener_token);
+        let _listener = Dispatcher::into_source_inner(self.dispatcher).unwrap();
+        // FIXME: Close socket?
+    }
 }
 
 /// Start the [`IpcServer`] for the compositor.
@@ -16,6 +35,20 @@ pub fn start(
     loop_handle: &LoopHandle<'static, State>,
     wayland_socket_name: &str,
 ) -> anyhow::Result<Server> {
+    // First setup the communication channel between the IPC server and compositor
+    let (to_compositor, from_clients) = calloop::channel::channel();
+    loop_handle
+        .insert_source(from_clients, |msg, _, state| {
+            let calloop::channel::Event::Msg(req) = msg else {
+                return;
+            };
+
+            if let Err(err) = state.handle_ipc_client_request(req) {
+                error!(?err, "Failed to handle IPC client request");
+            }
+        })
+        .map_err(|err| anyhow::anyhow!("Failed to insert calloop channel for IPC server: {err}"));
+
     let pid = std::process::id();
 
     // SAFETY: We place socket in XDG_RUNTIME_DIR, which should always be available to create the
@@ -30,20 +63,42 @@ pub fn start(
     let listener = UnixListener::bind(&socket_path)?;
     listener.set_nonblocking(true)?;
 
+    let to_compositor_ = to_compositor.clone();
     let generic = Generic::new(listener, Interest::READ, Mode::Level);
-    let registration_token = loop_handle.insert_source(generic, |_, listener, state| {
+    let dispatcher = Dispatcher::<_, State>::new(generic, move |_, listener, state| {
         match listener.accept() {
-            Ok((_stream, addr)) => {
-                info!(?addr, "New IPC client");
-                // TODO: Handle clients
+            Ok((socket, addr)) => {
+                debug!(?addr, "New IPC client");
+
+                // We want to make the socket driven by the event loop but have access to
+                // asynchronous primitives We use calloop's Async to achieve exactly
+                // this.
+
+                let Ok(socket) = state
+                    .fht
+                    .loop_handle
+                    .adapt_io(socket)
+                    .inspect_err(|err| error!(?err, "Failed to create IPC client stream"))
+                else {
+                    return Ok(PostAction::Continue);
+                };
+
+                let to_compositor = to_compositor_.clone();
+                let fut = async move {
+                    if let Err(err) = handle_new_client(socket, to_compositor).await {
+                        error!(?err, "Failed to handle IPC client");
+                    }
+                };
+
+                state.fht.scheduler.schedule(fut).unwrap();
             }
             Err(err) if err.kind() == io::ErrorKind::WouldBlock => (),
             Err(err) => return Err(err),
         }
 
-        // TODO: Handle clients
         Ok(PostAction::Continue)
-    })?;
+    });
+    let token = loop_handle.register_dispatcher(dispatcher.clone())?;
 
     unsafe {
         // SAFETY: We do not have any threaded activity **yet**
@@ -52,5 +107,128 @@ pub fn start(
 
     info!(?socket_path, "Started IPC");
 
-    Ok(Server { registration_token })
+    Ok(Server {
+        dispatcher,
+        listener_token: token,
+        to_compositor,
+    })
+}
+
+async fn handle_new_client(
+    stream: Async<'static, UnixStream>,
+    to_compositor: calloop::channel::Sender<ClientRequest>,
+) -> anyhow::Result<()> {
+    crate::profile_function!();
+    let (reader, mut writer) = stream.split();
+    let mut reader = futures_util::io::BufReader::new(reader);
+
+    // The IPC model requires each request to be on a single line.
+    let mut req_buf = String::new();
+    reader.read_line(&mut req_buf).await?;
+    let request = serde_json::from_str::<fht_compositor_ipc::Request>(&req_buf);
+
+    let response = match request {
+        Ok(req) => handle_request(req, to_compositor)
+            .await
+            .map_err(ToString::to_string),
+        Err(err) => Err(err.to_string()), // Just write an error string;
+    };
+
+    let mut response_str = serde_json::to_string(&response)?;
+    response_str.push('\n'); // separate by newlines
+    _ = writer.write(response_str.as_bytes()).await?;
+
+    Ok(())
+}
+
+enum ClientRequest {
+    Outputs(async_channel::Sender<HashMap<String, fht_compositor_ipc::Output>>),
+}
+
+async fn handle_request(
+    req: fht_compositor_ipc::Request,
+    to_compositor: calloop::channel::Sender<ClientRequest>,
+) -> Result<Response, &'static str> {
+    match req {
+        fht_compositor_ipc::Request::Version => {
+            Ok(Response::Version(crate::cli::get_version_string()))
+        }
+        fht_compositor_ipc::Request::Outputs => {
+            let (tx, rx) = async_channel::bounded(1);
+            to_compositor
+                .send(ClientRequest::Outputs(tx))
+                .context("IPC communication channel closed")?;
+            let outputs = rx
+                .recv()
+                .await
+                .map_err(|_| "Failed to retreive output information")?;
+
+            Ok(Response::Outputs(outputs))
+        }
+    }
+}
+
+impl State {
+    fn handle_ipc_client_request(&mut self, req: ClientRequest) -> anyhow::Result<()> {
+        match req {
+            ClientRequest::Outputs(tx) => {
+                let outputs = self
+                    .fht
+                    .space
+                    .outputs()
+                    .map(|output| {
+                        let name = output.name();
+                        let props = output.physical_properties();
+                        let preferred_mode = output.preferred_mode();
+                        let active_mode = output.current_mode();
+                        let mut active_mode_idx = None;
+
+                        let modes = output
+                            .modes()
+                            .into_iter()
+                            .enumerate()
+                            .map(|(idx, mode)| {
+                                if Some(mode) == active_mode {
+                                    assert!(
+                                        active_mode_idx.replace(idx).is_none(),
+                                        "Two active modes on output"
+                                    );
+                                }
+
+                                fht_compositor_ipc::OutputMode {
+                                    dimensions: (mode.size.w as u32, mode.size.h as u32),
+                                    preferred: Some(mode) == preferred_mode,
+                                    refresh: mode.refresh as f64 / 1000.,
+                                }
+                            })
+                            .collect();
+
+                        let position = output.current_location().into();
+                        let logical_size = output.geometry().size;
+                        let scale = output.current_scale().integer_scale();
+                        let transform = output.current_transform().into();
+
+                        let ipc_output = fht_compositor_ipc::Output {
+                            name: name.clone(),
+                            make: props.make,
+                            model: props.model,
+                            serial: output.serial(),
+                            physical_size: Some((props.size.w as u32, props.size.h as u32)),
+                            modes,
+                            active_mode_idx,
+                            position,
+                            size: (logical_size.w as u32, logical_size.h as u32),
+                            scale,
+                            transform,
+                        };
+
+                        (name, ipc_output)
+                    })
+                    .collect();
+                tx.send_blocking(outputs)?
+            }
+        }
+
+        Ok(())
+    }
 }

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -140,10 +140,12 @@ async fn handle_new_client(
     let request = serde_json::from_str::<fht_compositor_ipc::Request>(&req_buf);
 
     let response = match request {
-        Ok(req) => handle_request(req, to_compositor)
-            .await
-            .map_err(|err| err.to_string()),
-        Err(err) => Err(err.to_string()), // Just write an error string;
+        Ok(req) => match handle_request(req, to_compositor).await {
+            Ok(res) => res,
+            // We transform the Result::Err into a Response::Error
+            Err(err) => Response::Error(err.to_string()),
+        },
+        Err(err) => Response::Error(err.to_string()), // Just write an error string;
     };
 
     let mut response_str = serde_json::to_string(&response)?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -274,6 +274,11 @@ fn main() -> anyhow::Result<(), Box<dyn Error>> {
         })
         .expect("Failed to run the eventloop!");
 
+    // Stop the socket and remove it
+    if let Some(ipc_server) = state.fht.ipc_server.take() {
+        ipc_server.close(&loop_handle);
+    }
+
     std::mem::drop(event_loop);
     std::mem::drop(state);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -76,6 +76,14 @@ fn main() -> anyhow::Result<(), Box<dyn Error>> {
             clap_complete::generate(shell, &mut command, name, &mut std::io::stdout());
             std::process::exit(0); // we just want to generate completions, nothing much
         }
+        Some(cli::Command::Ipc { request, json }) => {
+            if let Err(err) = ipc::client::make_request(request, json) {
+                error!(?err, "Failed to execute IPC client request");
+                std::process::exit(-1);
+            }
+
+            std::process::exit(0);
+        }
         _ => (),
     }
     // Start tracy client now since everything before is just basic setup or command handling.

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,7 +13,6 @@ use std::str::FromStr;
 use std::sync::Arc;
 
 use clap::{CommandFactory, Parser};
-use libc::SOCK_RDM;
 use smithay::reexports::calloop::generic::{Generic, NoIoDrop};
 use smithay::reexports::calloop::{EventLoop, Interest, Mode};
 use smithay::reexports::wayland_server::Display;
@@ -52,7 +51,11 @@ fn main() -> anyhow::Result<(), Box<dyn Error>> {
     //
     // We must have at least one backend, otherwise unmatched branches will occur.
     // This also must be at the very top of the crate so that it pops ups before anything.
-    #[cfg(all(not(feature = "udev-backend"), not(feature = "winit-backend")))]
+    #[cfg(all(
+        not(feature = "udev-backend"),
+        not(feature = "winit-backend"),
+        not(feature = "headless-backend")
+    ))]
     compile_error!("You must enable at least one backend: 'udev-backend' or 'winit-backend");
 
     let filter = tracing_subscriber::EnvFilter::try_from_default_env().unwrap_or_else(|_| {

--- a/src/main.rs
+++ b/src/main.rs
@@ -190,6 +190,7 @@ fn main() -> anyhow::Result<(), Box<dyn Error>> {
             "XDG_CURRENT_DESKTOP",
             "XDG_SESSION_TYPE",
             "MOZ_ENABLE_WAYLAND",
+            "FHTC_SOCKET_PATH",
             "_JAVA_AWT_NONREPARENTING",
         ];
         let vars_str = vars.join(" ");

--- a/src/space/mod.rs
+++ b/src/space/mod.rs
@@ -296,6 +296,16 @@ impl Space {
         active_workspace.active_window()
     }
 
+    /// Get the active [`Monitor`] index of this [`Space`]
+    pub fn active_monitor_idx(&self) -> usize {
+        self.active_idx
+    }
+
+    /// Get the primary [`Monitor`] index of this [`Space`]
+    pub fn primary_monitor_idx(&self) -> usize {
+        self.primary_idx
+    }
+
     /// Get the active [`Window`] of this [`Space`], if any.
     pub fn active_monitor_mut(&mut self) -> &mut Monitor {
         &mut self.monitors[self.active_idx]

--- a/src/space/mod.rs
+++ b/src/space/mod.rs
@@ -289,6 +289,12 @@ impl Space {
         self.monitors.iter().any(|mon| mon.output() == output)
     }
 
+    /// Get the active [`Workspace`].
+    pub fn active_workspace(&self) -> &Workspace {
+        let monitor = &self.monitors[self.active_idx];
+        monitor.active_workspace()
+    }
+
     /// Get the [`WorkspaceId`] of the active [`Workspace`].
     pub fn active_workspace_id(&self) -> WorkspaceId {
         let monitor = &self.monitors[self.active_idx];
@@ -353,6 +359,13 @@ impl Space {
     /// Get the primary [`Output`].
     pub fn primary_output(&self) -> &Output {
         self.monitors[self.primary_idx].output()
+    }
+
+    /// Get the [`Workspace`] associated with this [`WorkspaceId`].
+    pub fn workspace_for_id(&self, workspace_id: WorkspaceId) -> Option<&Workspace> {
+        self.monitors
+            .iter()
+            .find_map(|mon| mon.workspaces().find(|ws| ws.id() == workspace_id))
     }
 
     /// Get the [`Workspace`] associated with this [`WorkspaceId`].

--- a/src/space/mod.rs
+++ b/src/space/mod.rs
@@ -21,7 +21,7 @@ use smithay::output::Output;
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 use smithay::utils::{Logical, Point, Rectangle};
 use smithay::wayland::seat::WaylandFocus;
-pub use tile::TileRenderElement;
+pub use tile::{Tile, TileRenderElement};
 #[allow(unused)] // re-export WorkspaceRenderElement for screencopy type bounds
 pub use workspace::{Workspace, WorkspaceId, WorkspaceRenderElement};
 

--- a/src/space/mod.rs
+++ b/src/space/mod.rs
@@ -163,6 +163,11 @@ impl Space {
         self.monitors.iter()
     }
 
+    /// Get a mutable iterator over the [`Space`]'s tracked [`Monitor`](s)
+    pub fn monitors_mut(&mut self) -> impl ExactSizeIterator<Item = &mut Monitor> {
+        self.monitors.iter_mut()
+    }
+
     /// Get the [`Monitor`] associated with this [`Output`].
     pub fn monitor_for_output(&self, output: &Output) -> Option<&Monitor> {
         self.monitors.iter().find(|mon| mon.output() == output)
@@ -207,12 +212,19 @@ impl Space {
     }
 
     /// Get an iterator of all the [`Windows`]s managed by this [`Space`].
-    #[allow(unused)]
     pub fn windows(&self) -> impl Iterator<Item = &Window> {
         self.monitors
             .iter()
             .flat_map(Monitor::workspaces)
             .flat_map(Workspace::windows)
+    }
+
+    /// Get a mutable iterator of all the [`Tile`]s managed by this [`Space`].
+    pub fn tiles_mut(&mut self) -> impl Iterator<Item = &mut tile::Tile> {
+        self.monitors
+            .iter_mut()
+            .flat_map(Monitor::workspaces_mut)
+            .flat_map(Workspace::tiles_mut)
     }
 
     /// Add an [`Output`] to this [`Space`].
@@ -294,6 +306,13 @@ impl Space {
         let active_monitor = &self.monitors[self.active_idx];
         let active_workspace = active_monitor.active_workspace();
         active_workspace.active_window()
+    }
+
+    /// Get a mutable reference to the active [`Tile`] of this [`Space`], if any.
+    pub fn active_tile_mut(&mut self) -> Option<&mut tile::Tile> {
+        let active_monitor = &mut self.monitors[self.active_idx];
+        let active_workspace = active_monitor.active_workspace_mut();
+        active_workspace.active_tile_mut()
     }
 
     /// Get the active [`Monitor`] index of this [`Space`]
@@ -595,6 +614,29 @@ impl Space {
         false
     }
 
+    /// Float the [`Tile`] associated with this [`Window`].
+    pub fn float_window(&mut self, window: &Window, floating: bool, animate: bool) -> bool {
+        for monitor in &mut self.monitors {
+            for workspace in monitor.workspaces_mut() {
+                let mut arrange = false;
+                for tile in workspace.tiles_mut() {
+                    if tile.window() == window {
+                        window.request_tiled(!floating);
+                        arrange = true;
+                        break;
+                    }
+                }
+
+                if arrange {
+                    workspace.arrange_tiles(animate);
+                    return true;
+                }
+            }
+        }
+
+        false
+    }
+
     /// Fullscreen the [`Tile`] associated with this [`Window`].
     pub fn fullscreen_window(&mut self, window: &Window, animate: bool) -> bool {
         for monitor in &mut self.monitors {
@@ -673,6 +715,48 @@ impl Space {
         active.insert_window(window.clone(), animate);
     }
 
+    /// Move this [`Window`] to a given [`Workspace`].
+    pub fn move_window_to_workspace(
+        &mut self,
+        window: &Window,
+        workspace_id: WorkspaceId,
+        animate: bool,
+    ) {
+        // If we try to add the window back into its original workspace.
+        let mut original_workspace_id = None;
+        'monitors: for monitor in &mut self.monitors {
+            for workspace in monitor.workspaces_mut() {
+                if workspace.remove_window(window, true) {
+                    // We successfully removed the window,
+                    // Stop checking for other monitors
+                    original_workspace_id = Some(workspace.id());
+                    break 'monitors;
+                }
+            }
+        }
+        let Some(original_workspace_id) = original_workspace_id else {
+            // We did not find the window!? Do not proceed.
+            return;
+        };
+
+        let Some(target_workspace) = self
+            .monitors
+            .iter_mut()
+            .find_map(|mon| mon.workspaces_mut().find(|ws| ws.id() == workspace_id))
+        else {
+            // No matching monitor, insert back
+            let original_workspace = self
+                .workspace_mut_for_id(original_workspace_id)
+                .expect("original_workspace_id should always be valid");
+            original_workspace.insert_window(window.clone(), animate);
+            return;
+        };
+
+        target_workspace.insert_window(window.clone(), animate);
+    }
+
+    /// Get the fullscreen [`Window`] under the `point`, and its position in global space.
+
     /// Get the fullscreen [`Window`] under the `point`, and its position in global space.
     ///
     /// `point` is expected to be in global coordinate space.
@@ -717,6 +801,33 @@ impl Space {
                     if tile.window() == window {
                         let proportion = (tile.proportion() + delta).max(0.01);
                         tile.set_proportion(proportion);
+                        arrange = true;
+                        break;
+                    }
+                }
+
+                if arrange {
+                    workspace.arrange_tiles(animate);
+                    return;
+                }
+            }
+        }
+    }
+
+    /// Center a given window.
+    pub fn center_window(&mut self, window: &Window, animate: bool) {
+        if window.tiled() {
+            return;
+        }
+
+        for monitor in &mut self.monitors {
+            for workspace in monitor.workspaces_mut() {
+                let mut arrange = false;
+                let output_geometry = workspace.output().geometry();
+                for tile in workspace.tiles_mut() {
+                    if tile.window() == window {
+                        let size = tile.size();
+                        tile.set_location(output_geometry.center() - size.downscale(2), animate);
                         arrange = true;
                         break;
                     }

--- a/src/space/mod.rs
+++ b/src/space/mod.rs
@@ -325,7 +325,12 @@ impl Space {
         self.primary_idx
     }
 
-    /// Get the active [`Window`] of this [`Space`], if any.
+    /// Get the active [`Monitor`] of this [`Space`], if any.
+    pub fn active_monitor(&self) -> &Monitor {
+        &self.monitors[self.active_idx]
+    }
+
+    /// Get the active [`Monitor`] of this [`Space`], if any.
     pub fn active_monitor_mut(&mut self) -> &mut Monitor {
         &mut self.monitors[self.active_idx]
     }

--- a/src/space/mod.rs
+++ b/src/space/mod.rs
@@ -21,7 +21,7 @@ use smithay::output::Output;
 use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
 use smithay::utils::{Logical, Point, Rectangle};
 use smithay::wayland::seat::WaylandFocus;
-pub use tile::{Tile, TileRenderElement};
+pub use tile::TileRenderElement;
 #[allow(unused)] // re-export WorkspaceRenderElement for screencopy type bounds
 pub use workspace::{Workspace, WorkspaceId, WorkspaceRenderElement};
 

--- a/src/space/monitor.rs
+++ b/src/space/monitor.rs
@@ -97,6 +97,11 @@ impl Monitor {
         &self.output
     }
 
+    /// Get whether this monitor is active
+    pub fn active(&self) -> bool {
+        self.is_active
+    }
+
     /// Get an iterator over the monitor's [`Workspace`]s.
     pub fn workspaces(&self) -> impl ExactSizeIterator<Item = &Workspace> {
         self.workspaces.iter()

--- a/src/space/workspace.rs
+++ b/src/space/workspace.rs
@@ -1614,11 +1614,18 @@ impl Workspace {
             return None;
         };
 
-        // FIXME: Perhaps handle better maximized/fullscreen?
-        // Would be janky though.
-        if window.maximized() || window.fullscreen() {
-            return None;
+        if window.fullscreen() {
+            // Fullscreening should be exclusive.
+            assert_eq!(self.fullscreened_window().as_ref(), Some(window));
+            window.request_fullscreen(false);
+            self.fullscreened_tile_idx = None;
+            // Start fading in windows as we grab the fullscreened tile
+            self.start_fullscreen_fade_in(None);
         }
+
+        // Reset window state
+        window.request_fullscreen(false);
+        window.request_maximized(false);
 
         let tile = self.tiles.remove(idx);
         if idx < self.nmaster {

--- a/src/space/workspace.rs
+++ b/src/space/workspace.rs
@@ -26,7 +26,7 @@ static WORKSPACE_IDS: AtomicUsize = AtomicUsize::new(0);
 
 /// Identifier of a [`Workspace`].
 #[derive(Clone, Copy, Hash, PartialEq, Eq)]
-pub struct WorkspaceId(usize);
+pub struct WorkspaceId(pub usize);
 impl WorkspaceId {
     /// Create a unique [`WorkspaceId`].
     ///
@@ -1081,6 +1081,13 @@ impl Workspace {
         self.arrange_tiles(animate);
     }
 
+    /// Set the master width factor of this [`Workspace`].
+    pub fn set_mwfact(&mut self, value: f64, animate: bool) {
+        self.has_transient_layout_changes = true;
+        self.mwfact = value.clamp(0.01, 0.99);
+        self.arrange_tiles(animate);
+    }
+
     /// The number of master windows factor of this [`Workspace`].
     pub fn nmaster(&self) -> usize {
         self.nmaster
@@ -1090,6 +1097,13 @@ impl Workspace {
     pub fn change_nmaster(&mut self, delta: i32, animate: bool) {
         self.has_transient_layout_changes = true;
         self.nmaster = self.nmaster.saturating_add_signed(delta as isize).max(1);
+        self.arrange_tiles(animate);
+    }
+
+    /// Set the number of master windows of this [`Workspace`].
+    pub fn set_nmaster(&mut self, value: usize, animate: bool) {
+        self.has_transient_layout_changes = true;
+        self.nmaster = value.max(1);
         self.arrange_tiles(animate);
     }
 

--- a/src/space/workspace.rs
+++ b/src/space/workspace.rs
@@ -40,6 +40,12 @@ impl std::fmt::Debug for WorkspaceId {
         write!(f, "workspace-{}", self.0)
     }
 }
+impl std::ops::Deref for WorkspaceId {
+    type Target = usize;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
 
 #[derive(Debug)]
 struct InteractiveResize {
@@ -1001,6 +1007,11 @@ impl Workspace {
         }
     }
 
+    /// Get the current fullscreened [`Tile`] index.
+    pub fn fullscreened_tile_idx(&self) -> Option<usize> {
+        self.fullscreened_tile_idx
+    }
+
     /// Get the current fullscreened [`Window`]
     pub fn fullscreened_window(&self) -> Option<Window> {
         self.tiles
@@ -1058,11 +1069,21 @@ impl Workspace {
         self.arrange_tiles(animate);
     }
 
+    /// The master width factor of this [`Workspace`].
+    pub fn mwfact(&self) -> f64 {
+        self.mwfact
+    }
+
     /// Change the master width factor of this [`Workspace`].
     pub fn change_mwfact(&mut self, delta: f64, animate: bool) {
         self.has_transient_layout_changes = true;
         self.mwfact = (self.mwfact + delta).clamp(0.01, 0.99);
         self.arrange_tiles(animate);
+    }
+
+    /// The number of master windows factor of this [`Workspace`].
+    pub fn nmaster(&self) -> usize {
+        self.nmaster
     }
 
     /// Change the number of master windows of this [`Workspace`].

--- a/src/state.rs
+++ b/src/state.rs
@@ -113,6 +113,10 @@ impl State {
                 cli::BackendType::Udev => crate::backend::udev::UdevData::new(&mut fht)
                     .unwrap()
                     .into(),
+                #[cfg(feature = "headless-backend")]
+                cli::BackendType::Headless => {
+                    crate::backend::headless::HeadlessData::new(&mut fht).into()
+                }
             }
         } else if std::env::var("DISPLAY").is_ok() || std::env::var("WAYLAND_DISPLAY").is_ok() {
             info!("Detected (WAYLAND_)DISPLAY. Running in nested Winit window");
@@ -535,7 +539,8 @@ impl State {
 
             let render_formats = self
                 .backend
-                .with_renderer(|renderer| renderer.egl_context().dmabuf_render_formats().clone());
+                .with_renderer(|renderer| renderer.egl_context().dmabuf_render_formats().clone())
+                .expect("we should be in Udev backend when starting screencast");
 
             let (to_compositor, from_pw) = calloop::channel::channel();
             let token = self

--- a/src/state.rs
+++ b/src/state.rs
@@ -953,6 +953,21 @@ impl Fht {
         }
     }
 
+    pub fn focus_output(&mut self, output: &Output) {
+        if let Some(window) = self.space.set_active_output(output) {
+            self.loop_handle.insert_idle(move |state| {
+                state.set_keyboard_focus(Some(window));
+            });
+
+            if self.config.general.cursor_warps {
+                let center = output.geometry().center();
+                self.loop_handle.insert_idle(move |state| {
+                    state.move_pointer(center.to_f64());
+                });
+            }
+        }
+    }
+
     pub fn output_resized(&mut self, output: &Output) {
         crate::profile_function!();
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::Context;
-use calloop::futures::{Executor, Scheduler};
+use calloop::futures::Scheduler;
 use fht_compositor_config::{BlurOverrides, BorderOverrides, DecorationMode, ShadowOverrides};
 use smithay::backend::renderer::element::utils::select_dmabuf_feedback;
 use smithay::backend::renderer::element::{

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -4,6 +4,9 @@ use std::process::Stdio;
 use std::time::Duration;
 
 use smithay::reexports::rustix;
+use smithay::reexports::wayland_server::backend::Credentials;
+use smithay::reexports::wayland_server::protocol::wl_surface::WlSurface;
+use smithay::reexports::wayland_server::{DisplayHandle, Resource};
 use smithay::utils::{Coordinate, Point, Rectangle};
 
 #[cfg(feature = "xdg-screencast-portal")]
@@ -85,6 +88,13 @@ pub fn spawn(cmd: &str) {
     if let Err(err) = res {
         warn!(?err, "Failed to create command spawner for command")
     }
+}
+
+pub fn get_credentials_for_surface(surface: &WlSurface) -> Option<Credentials> {
+    let handle = surface.handle().upgrade()?;
+    let dh = DisplayHandle::from(handle);
+    let client = dh.get_client(surface.id()).ok()?;
+    client.get_credentials(&dh).ok()
 }
 
 pub trait RectCenterExt<C: Coordinate, Kind> {

--- a/src/window.rs
+++ b/src/window.rs
@@ -56,7 +56,7 @@ impl IsAlive for Window {
 
 static WINDOW_IDS: AtomicUsize = AtomicUsize::new(0);
 #[derive(Clone, Copy, Debug, Hash, PartialEq, Eq)]
-pub struct WindowId(usize);
+pub struct WindowId(pub usize);
 impl WindowId {
     pub fn unique() -> Self {
         Self(WINDOW_IDS.fetch_add(1, Ordering::SeqCst))

--- a/src/window.rs
+++ b/src/window.rs
@@ -63,6 +63,13 @@ impl WindowId {
     }
 }
 
+impl std::ops::Deref for WindowId {
+    type Target = usize;
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
 #[derive(Debug)]
 struct WindowInner {
     id: WindowId,

--- a/src/window.rs
+++ b/src/window.rs
@@ -69,6 +69,11 @@ impl std::ops::Deref for WindowId {
         &self.0
     }
 }
+impl PartialEq<usize> for WindowId {
+    fn eq(&self, other: &usize) -> bool {
+        self.0 == *other
+    }
+}
 
 #[derive(Debug)]
 struct WindowInner {


### PR DESCRIPTION
Closes #3

The IPC allows the user to fetch data from the compositor and also request the compositor some
actions. This in turns open up a **lot** of possibilities (notably with shell-scripting, using the `fht-compositor ipc` command line)

There are two main ways to use the IPC
- `fht-compositor ipc` command line, you can optionally pass in `--json/-j` to get a JSON-formatted output, which you can then parse using tools like [jq](https://jqlang.org/) to have very fine output. You can get really far using this
- Using the `fht-compositor-ipc` library, which backs <small>the very simple wrapper</small> `fht-compositor ipc`. This is useful if you want to integrate fht-compositor's IPC capabilities into other Rust codebases.

## TO-DO

- [x] Basic IPC socket using `UnixSocket`
- [x] `Version` request, returns the version of the running compositor
- [x] `Outputs` request, return all connected *outputs* (not monitors!)
- [x] `Windows` request, return all *mapped windows* (IE. ones that are inside workspaces)
- [x] `Space` request, return information about the current `Space`, `Monitors`, and `Workspaces`
- [x] `Action` request, allowing the user to make changes, just like key actions in keybinds 
- [x] `PickWindow` request, similar to what `xprop` allows you to-do
- [x] `FocusedWindow`, `FocusedWorkspace`, self-explainatory
- [x] `GetWorkspaceId`, allows you to get a `workspace-id` argument (to use inside actions) from an output name and workspace index.
- [x] `LayerShells` request, return all mapped layer-shells
- ~~[ ] `Output` (*without* s), expose a xrandr-like interface to manage outputs~~ Better left to tools like wlr-randr, or the config file.
- ~~[ ] `Subscribe`, allowing you to continuously receive events, very useful for status bars or shells trying to integrate with the compositor (think workspace indicator, that sort of stuff)~~ Postponed to a later pull request

**NOTE**: I currently do not like how `Space` is currently handled as it does a loop on all monitors, all workspaces, and all windows to gather data. Perhaps a "smarter" way to do this is by tracking the state with shared-data between the space and compositor state, or maybe just refresh that on `State::dispatch` under some interval.