### PR TITLE
Blur rendering fixes

### DIFF
--- a/docs/usage/ipc.md
+++ b/docs/usage/ipc.md
@@ -47,7 +47,7 @@ have to resort to polling every few seconds.
 
 ::: tabs
 == Example with eww
-```yuck
+```scheme
 ; Here, we store the space data into a global variable, updated each second.
 ; Since eww supports native JSON decoding, this is really handy
 (defpoll space-data :interval "1s"

--- a/src/renderer/blur/mod.rs
+++ b/src/renderer/blur/mod.rs
@@ -16,17 +16,17 @@ use std::rc::Rc;
 
 use anyhow::Context;
 use glam::Mat3;
-use shader::BlurShaders;
 use smithay::backend::renderer::element::surface::WaylandSurfaceRenderElement;
 use smithay::backend::renderer::element::AsRenderElements;
-use smithay::backend::renderer::gles::format::fourcc_to_gl_formats;
-use smithay::backend::renderer::gles::{ffi, Capability, GlesError, GlesRenderer, GlesTexture};
+use smithay::backend::renderer::gles::{
+    ffi, Capability, GlesError, GlesFrame, GlesRenderer, GlesTexture,
+};
 use smithay::backend::renderer::glow::GlowRenderer;
 use smithay::backend::renderer::{Bind, Blit, Frame, Offscreen, Renderer, Texture, TextureFilter};
 use smithay::desktop::layer_map_for_output;
 use smithay::output::Output;
 use smithay::reexports::gbm::Format;
-use smithay::utils::{Physical, Point, Rectangle, Size, Transform};
+use smithay::utils::{Logical, Physical, Point, Rectangle, Size, Transform};
 use smithay::wayland::shell::wlr_layer::Layer;
 
 use super::data::RendererData;
@@ -94,17 +94,13 @@ impl EffectsFramebuffers {
     pub fn init_for_output(output: &Output, renderer: &mut impl FhtRenderer) {
         // FIXME: Not panic here?
         let renderer = renderer.glow_renderer_mut();
-        let scale = output.current_scale().integer_scale();
-        let output_size = output.geometry().size.to_physical(scale);
+        let output_size = output.geometry().size;
 
         fn create_buffer(
             renderer: &mut GlowRenderer,
-            size: Size<i32, Physical>,
+            size: Size<i32, Logical>,
         ) -> Result<GlesTexture, GlesError> {
-            renderer.create_buffer(
-                Format::Abgr8888,
-                size.to_logical(1).to_buffer(1, Transform::Normal),
-            )
+            renderer.create_buffer(Format::Abgr8888, size.to_buffer(1, Transform::Normal))
         }
 
         let this = EffectsFramebuffers {
@@ -131,17 +127,13 @@ impl EffectsFramebuffers {
     ) -> Result<(), GlesError> {
         let renderer = renderer.glow_renderer_mut();
         let mut fx_buffers = Self::get(output);
-        let scale = output.current_scale().integer_scale();
-        let output_size = output.geometry().size.to_physical(scale);
+        let output_size = output.geometry().size;
 
         fn create_buffer(
             renderer: &mut GlowRenderer,
-            size: Size<i32, Physical>,
+            size: Size<i32, Logical>,
         ) -> Result<GlesTexture, GlesError> {
-            renderer.create_buffer(
-                Format::Abgr8888,
-                size.to_logical(1).to_buffer(1, Transform::Normal),
-            )
+            renderer.create_buffer(Format::Abgr8888, size.to_buffer(1, Transform::Normal))
         }
 
         *fx_buffers = EffectsFramebuffers {
@@ -266,7 +258,7 @@ fn render_blur_pass_with_frame(
     renderer: &mut GlowRenderer,
     sample_buffer: &GlesTexture,
     render_buffer: &mut GlesTexture,
-    blur_program: &shader::BlurShader,
+    program: &shader::BlurShader,
     half_pixel: [f32; 2],
     config: &fht_compositor_config::Blur,
 ) -> anyhow::Result<()> {
@@ -286,7 +278,6 @@ fn render_blur_pass_with_frame(
         .context("failed to create frame")?;
 
     let supports_instaning = frame.capabilities().contains(&Capability::Instancing);
-    let debug = !frame.debug_flags().is_empty();
     let projection = Mat3::from_cols_array(frame.projection());
 
     let tex_size = sample_buffer.size();
@@ -336,18 +327,6 @@ fn render_blur_pass_with_frame(
         };
 
         mat *= projection;
-
-        // SAFETY: internal texture should always have a format
-        // We also use Abgr8888 which is known and confirmed
-        let (internal_format, _, _) =
-            fourcc_to_gl_formats(sample_buffer.format().unwrap()).unwrap();
-        let variant = blur_program.variant_for_format(Some(internal_format), false);
-
-        let program = if debug {
-            &variant.debug
-        } else {
-            &variant.normal
-        };
 
         gl.ActiveTexture(ffi::TEXTURE0);
         gl.BindTexture(ffi::TEXTURE_2D, sample_buffer.tex_id());
@@ -425,281 +404,194 @@ fn render_blur_pass_with_frame(
     Ok(())
 }
 
-// Renders a blur pass using gl code bypassing smithay's Frame mechanisms
-//
-// When rendering blur in real-time (for windows, for example) there should not be a wait for
-// fencing/finishing since this will be done when sending the fb to the output. Using a Frame
-// forces us to do that.
-#[allow(clippy::too_many_arguments)]
-unsafe fn render_blur_pass_with_gl(
-    gl: &ffi::Gles2,
-    vbos: &[u32; 2],
-    debug: bool,
-    supports_instancing: bool,
-    projection_matrix: Mat3,
-    // The buffers used for blurring
-    sample_buffer: &GlesTexture,
-    render_buffer: &mut GlesTexture,
-    scale: i32,
-    // The current blur program + config
-    blur_program: &shader::BlurShader,
-    half_pixel: [f32; 2],
-    config: &fht_compositor_config::Blur,
-    // dst is the region that should have blur
-    // it gets up/downscaled with passes
+/// Get a blurred texture for a given region. The region is used as damage.
+fn get_blurred_contents(
+    frame: &mut GlesFrame,
+    output: &Output,
     damage: Rectangle<i32, Physical>,
-) -> Result<(), GlesError> {
-    crate::profile_function!();
-    let tex_size = sample_buffer.size();
-    let src = Rectangle::from_size(tex_size.to_f64());
-    let dest = src
-        .to_logical(1.0, Transform::Normal, &src.size)
-        .to_physical(scale as f64)
-        .to_i32_round();
-
-    // FIXME: Should we call gl.Finish() when done rendering this pass? If yes, should we check
-    // if the gl context is shared or not? What about fencing, we don't have access to that
-
-    // PERF: Instead of taking the whole src/dst as damage, adapt the code to run with only the
-    // damaged window? This would cause us to make a custom WaylandSurfaceRenderElement to blur out
-    // stuff. Complicated.
-
-    // First bind to our render buffer
-    let mut render_buffer_fbo = 0;
-    {
-        crate::profile_scope!("bind to render texture");
-        gl.GenFramebuffers(1, &mut render_buffer_fbo as *mut _);
-        gl.BindFramebuffer(ffi::FRAMEBUFFER, render_buffer_fbo);
-        gl.FramebufferTexture2D(
-            ffi::FRAMEBUFFER,
-            ffi::COLOR_ATTACHMENT0,
-            ffi::TEXTURE_2D,
-            render_buffer.tex_id(),
-            0,
-        );
-
-        let status = gl.CheckFramebufferStatus(ffi::FRAMEBUFFER);
-        if status != ffi::FRAMEBUFFER_COMPLETE {
-            return Err(GlesError::FramebufferBindingError);
-        }
-    }
-
-    {
-        crate::profile_scope!("render blur pass to texture");
-
-        let mat = projection_matrix;
-        // NOTE: We are assured that tex_size != 0, and src.size != too (by damage tracker)
-        let mut tex_mat = super::build_texture_mat(src, dest, tex_size, Transform::Normal);
-        if sample_buffer.is_y_inverted() {
-            tex_mat *= Mat3::from_cols_array(&[1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 1.0]);
-        }
-
-        gl.Disable(ffi::BLEND);
-
-        // FIXME: Use actual damage for this? Would require making a custom window render element
-        // that includes blur and whatnot to get the damage for the window only
-        let damage = [
-            damage.loc.x as f32,
-            damage.loc.y as f32,
-            damage.size.w as f32,
-            damage.size.h as f32,
-        ];
-
-        let mut vertices = Vec::with_capacity(4);
-        let damage_len = if supports_instancing {
-            vertices.extend(damage);
-            vertices.len() / 4
-        } else {
-            for _ in 0..6 {
-                // Add the 4 f32s per damage rectangle for each of the 6 vertices.
-                vertices.extend_from_slice(&damage);
-            }
-
-            1
-        };
-
-        // SAFETY: internal texture should always have a format
-        // We also use Abgr8888 which is known and confirmed
-        let (internal_format, _, _) =
-            fourcc_to_gl_formats(sample_buffer.format().unwrap()).unwrap();
-        let variant = blur_program.variant_for_format(Some(internal_format), false);
-
-        let program = if debug {
-            &variant.debug
-        } else {
-            &variant.normal
-        };
-
-        gl.ActiveTexture(ffi::TEXTURE0);
-        gl.BindTexture(ffi::TEXTURE_2D, sample_buffer.tex_id());
-        gl.TexParameteri(ffi::TEXTURE_2D, ffi::TEXTURE_MIN_FILTER, ffi::LINEAR as i32);
-        gl.TexParameteri(ffi::TEXTURE_2D, ffi::TEXTURE_MAG_FILTER, ffi::LINEAR as i32);
-        gl.UseProgram(program.program);
-
-        gl.Uniform1i(program.uniform_tex, 0);
-        gl.UniformMatrix3fv(
-            program.uniform_matrix,
-            1,
-            ffi::FALSE,
-            mat.as_ref() as *const f32,
-        );
-        gl.UniformMatrix3fv(
-            program.uniform_tex_matrix,
-            1,
-            ffi::FALSE,
-            tex_mat.as_ref() as *const f32,
-        );
-        gl.Uniform1f(program.uniform_alpha, 1.0);
-        gl.Uniform1f(program.uniform_radius, config.radius);
-        gl.Uniform2f(program.uniform_half_pixel, half_pixel[0], half_pixel[1]);
-
-        gl.EnableVertexAttribArray(program.attrib_vert as u32);
-        gl.BindBuffer(ffi::ARRAY_BUFFER, vbos[0]);
-        gl.VertexAttribPointer(
-            program.attrib_vert as u32,
-            2,
-            ffi::FLOAT,
-            ffi::FALSE,
-            0,
-            std::ptr::null(),
-        );
-
-        // vert_position
-        gl.EnableVertexAttribArray(program.attrib_vert_position as u32);
-        gl.BindBuffer(ffi::ARRAY_BUFFER, 0);
-
-        gl.VertexAttribPointer(
-            program.attrib_vert_position as u32,
-            4,
-            ffi::FLOAT,
-            ffi::FALSE,
-            0,
-            vertices.as_ptr() as *const _,
-        );
-
-        if supports_instancing {
-            gl.VertexAttribDivisor(program.attrib_vert as u32, 0);
-            gl.VertexAttribDivisor(program.attrib_vert_position as u32, 1);
-            gl.DrawArraysInstanced(ffi::TRIANGLE_STRIP, 0, 4, damage_len as i32);
-        } else {
-            let count = damage_len * 6;
-            gl.DrawArrays(ffi::TRIANGLES, 0, count as i32);
-        }
-
-        gl.BindTexture(ffi::TEXTURE_2D, 0);
-        gl.DisableVertexAttribArray(program.attrib_vert as u32);
-        gl.DisableVertexAttribArray(program.attrib_vert_position as u32);
-    }
-
-    // Clean up
-    {
-        crate::profile_scope!("clean up blur pass");
-        gl.Enable(ffi::BLEND);
-        gl.DeleteFramebuffers(1, &render_buffer_fbo as *const _);
-        gl.BlendFunc(ffi::ONE, ffi::ONE_MINUS_SRC_ALPHA);
-        gl.BindFramebuffer(ffi::FRAMEBUFFER, 0);
-    }
-
-    Ok(())
-}
-
-#[allow(clippy::too_many_arguments)]
-pub(super) unsafe fn get_main_buffer_blur(
-    gl: &ffi::Gles2,
-    fx_buffers: &mut EffectsFramebuffers,
-    shaders: &BlurShaders,
-    blur_config: &fht_compositor_config::Blur,
-    projection_matrix: Mat3,
     scale: i32,
-    vbos: &[u32; 2],
-    debug: bool,
-    supports_instancing: bool,
-    // dst is the region that we want blur on
-    dst: Rectangle<i32, Physical>,
+    blur_config: &fht_compositor_config::Blur,
 ) -> Result<GlesTexture, GlesError> {
-    let tex_size = fx_buffers
-        .effects
-        .size()
-        .to_logical(1, Transform::Normal)
-        .to_physical(scale);
-    let dst_expanded = {
-        let mut dst = dst;
-        let size = (2f32.powi(blur_config.passes as i32 + 1) * blur_config.radius).ceil() as i32;
-        dst.loc -= Point::from((size, size));
-        dst.size += Size::from((size, size)).upscale(2);
-        dst
+    let shaders = Shaders::get_from_frame(frame).blur.clone();
+    let vbos = RendererData::get_from_frame(frame).vbos;
+    let instancing = frame.capabilities().contains(&Capability::Instancing);
+    let projection_matrix = glam::Mat3::from_cols_array(frame.projection());
+    let fht_compositor_config::Blur { passes, radius, .. } = *blur_config;
+
+    // We must expand the damage with the blur to damage appropriatly.
+    let blur_size = (2f32.powi(passes as i32 + 1) * radius).ceil() as i32 * scale;
+    let damage = {
+        let mut rect = damage;
+        rect.loc -= Point::from((blur_size, blur_size));
+        rect.size += Size::from((blur_size, blur_size)).upscale(2);
+        rect
     };
 
-    let mut prev_fbo = 0;
-    gl.GetIntegerv(ffi::FRAMEBUFFER_BINDING, &mut prev_fbo as *mut _);
+    let mut fx_buffers = EffectsFramebuffers::get(output);
+    fx_buffers.current_buffer = CurrentBuffer::Normal;
 
-    let (sample_buffer, _) = fx_buffers.buffers();
+    let blurred_buffer = frame.with_context(move |gl| unsafe {
+        // Read previous framebuffer we were bound to
+        let mut prev_fbo = 0;
+        gl.GetIntegerv(ffi::FRAMEBUFFER_BINDING, &mut prev_fbo as *mut _);
 
-    // First get a fbo for the texture we are about to read into
-    let mut sample_fbo = 0u32;
-    {
-        gl.GenFramebuffers(1, &mut sample_fbo as *mut _);
-        gl.BindFramebuffer(ffi::DRAW_FRAMEBUFFER, sample_fbo);
-        gl.FramebufferTexture2D(
-            ffi::FRAMEBUFFER,
-            ffi::COLOR_ATTACHMENT0,
-            ffi::TEXTURE_2D,
-            sample_buffer.tex_id(),
-            0,
-        );
-        gl.Clear(ffi::COLOR_BUFFER_BIT);
-        let status = gl.CheckFramebufferStatus(ffi::FRAMEBUFFER);
-        if status != ffi::FRAMEBUFFER_COMPLETE {
-            gl.DeleteFramebuffers(1, &mut sample_fbo as *mut _);
-            return Err(GlesError::FramebufferBindingError);
+        let (sample_buffer, _) = fx_buffers.buffers();
+
+        // First, we the sample framebuffer contents using a blit.
+        //
+        // TODO: Avoid using blit by drawing from the render buffer into the texture buffer, this
+        // would remove the OpenGL 3.0 dependency for blur to work.
+        {
+            let mut sample_buffer_fbo = create_texture_fbo(gl, sample_buffer)?;
+            gl.BindFramebuffer(ffi::DRAW_FRAMEBUFFER, sample_buffer_fbo);
+            gl.BlitFramebuffer(
+                damage.loc.x,
+                damage.loc.y,
+                damage.loc.x + damage.size.w,
+                damage.loc.y + damage.size.h,
+                damage.loc.x,
+                damage.loc.y,
+                damage.loc.x + damage.size.w,
+                damage.loc.y + damage.size.h,
+                ffi::COLOR_BUFFER_BIT,
+                ffi::LINEAR,
+            );
+            // Dont forget to cleanup the fbo after blitting
+            gl.BindFramebuffer(ffi::DRAW_FRAMEBUFFER, 0);
+            gl.DeleteFramebuffers(1, &mut sample_buffer_fbo as _);
+
+            if gl.GetError() == ffi::INVALID_OPERATION {
+                error!("TrueBlur needs GLES3.0 for blitting");
+                return Err(GlesError::BlitError);
+            }
         }
-    }
 
-    {
-        // NOTE: We are assured that the size of the effects texture is the same
-        // as the bound fbo size, so blitting uses dst immediatly
-        gl.BindFramebuffer(ffi::DRAW_FRAMEBUFFER, sample_fbo);
-        gl.BlitFramebuffer(
-            dst_expanded.loc.x,
-            dst_expanded.loc.y,
-            dst_expanded.loc.x + dst_expanded.size.w,
-            dst_expanded.loc.y + dst_expanded.size.h,
-            dst_expanded.loc.x,
-            dst_expanded.loc.y,
-            dst_expanded.loc.x + dst_expanded.size.w,
-            dst_expanded.loc.y + dst_expanded.size.h,
-            ffi::COLOR_BUFFER_BIT,
-            ffi::LINEAR,
-        );
-
-        if gl.GetError() == ffi::INVALID_OPERATION {
-            error!("TrueBlur needs GLES3.0 for blitting");
-            return Err(GlesError::BlitError);
+        let tex_size = sample_buffer.size();
+        // NOTE: Source and dst are always the same since we are not stretching the texture
+        // around, it will always be drawn on top of the whole output.
+        let src = Rectangle::from_size(tex_size.to_f64());
+        let dest = src
+            .to_logical(1.0, Transform::Normal, &src.size)
+            .to_physical_precise_round::<_, i32>(scale);
+        // NOTE: We are assured that tex_size != 0, and src.size != too (by damage tracker)
+        let mut texture_matrix = super::build_texture_mat(src, dest, tex_size, Transform::Normal);
+        if sample_buffer.is_y_inverted() {
+            texture_matrix *=
+                Mat3::from_cols_array(&[1.0, 0.0, 0.0, 0.0, -1.0, 0.0, 0.0, 0.0, 1.0]);
         }
-    }
 
-    {
-        let passes = blur_config.passes;
+        let draw_pass = |render_buffer: &GlesTexture,
+                         sample_buffer: &GlesTexture,
+                         program: &shader::BlurShader,
+                         damage: Rectangle<i32, Physical>,
+                         half_pixel: [f32; 2]|
+         -> Result<(), GlesError> {
+            crate::profile_function!();
+
+            let render_fbo = create_texture_fbo(gl, render_buffer)?;
+
+            // Transform damage into vertices
+            let damage = [
+                damage.loc.x as f32,
+                damage.loc.y as f32,
+                damage.size.w as f32,
+                damage.size.h as f32,
+            ];
+
+            let mut vertices = Vec::with_capacity(4);
+            let damage_len = if instancing {
+                vertices.extend(damage);
+                vertices.len() / 4
+            } else {
+                for _ in 0..6 {
+                    // Add the 4 f32s per damage rectangle for each of the 6 vertices.
+                    vertices.extend_from_slice(&damage);
+                }
+
+                1
+            };
+
+            // Prepare sample texture target
+            gl.ActiveTexture(ffi::TEXTURE0);
+            gl.BindTexture(ffi::TEXTURE_2D, sample_buffer.tex_id());
+            gl.TexParameteri(ffi::TEXTURE_2D, ffi::TEXTURE_MIN_FILTER, ffi::LINEAR as i32);
+            gl.TexParameteri(ffi::TEXTURE_2D, ffi::TEXTURE_MAG_FILTER, ffi::LINEAR as i32);
+
+            // Setup program and uniforms
+            gl.UseProgram(program.program);
+            gl.Uniform1f(program.uniform_alpha, 1.0);
+            gl.Uniform1f(program.uniform_radius, radius);
+            gl.Uniform2f(program.uniform_half_pixel, half_pixel[0], half_pixel[1]);
+
+            gl.Uniform1i(program.uniform_tex, 0);
+            gl.UniformMatrix3fv(
+                program.uniform_matrix,
+                1,
+                ffi::FALSE,
+                projection_matrix.as_ref() as *const f32,
+            );
+            gl.UniformMatrix3fv(
+                program.uniform_tex_matrix,
+                1,
+                ffi::FALSE,
+                texture_matrix.as_ref() as *const f32,
+            );
+
+            gl.EnableVertexAttribArray(program.attrib_vert as u32);
+            gl.BindBuffer(ffi::ARRAY_BUFFER, vbos[0]);
+            gl.VertexAttribPointer(
+                program.attrib_vert as u32,
+                2,
+                ffi::FLOAT,
+                ffi::FALSE,
+                0,
+                std::ptr::null(),
+            );
+
+            // vert_position
+            gl.EnableVertexAttribArray(program.attrib_vert_position as u32);
+            gl.BindBuffer(ffi::ARRAY_BUFFER, 0);
+            gl.VertexAttribPointer(
+                program.attrib_vert_position as u32,
+                4,
+                ffi::FLOAT,
+                ffi::FALSE,
+                0,
+                vertices.as_ptr() as *const _,
+            );
+
+            if instancing {
+                gl.VertexAttribDivisor(program.attrib_vert as u32, 0);
+                gl.VertexAttribDivisor(program.attrib_vert_position as u32, 1);
+                gl.DrawArraysInstanced(ffi::TRIANGLE_STRIP, 0, 4, damage_len as i32);
+            } else {
+                let count = damage_len * 6;
+                gl.DrawArrays(ffi::TRIANGLES, 0, count as i32);
+            }
+
+            // Cleanup
+            gl.BindTexture(ffi::TEXTURE_2D, 0);
+            gl.DisableVertexAttribArray(program.attrib_vert as u32);
+            gl.DisableVertexAttribArray(program.attrib_vert_position as u32);
+            gl.DeleteFramebuffers(1, &render_fbo as *const _);
+
+            Ok(())
+        };
+
+        // Now, draw passes
         let half_pixel = [
             0.5 / (tex_size.w as f32 / 2.0),
             0.5 / (tex_size.h as f32 / 2.0),
         ];
+
         for i in 0..passes {
             let (sample_buffer, render_buffer) = fx_buffers.buffers();
-            let damage = dst_expanded.downscale(1 << (i + 1));
-            render_blur_pass_with_gl(
-                gl,
-                vbos,
-                debug,
-                supports_instancing,
-                projection_matrix,
-                sample_buffer,
+            draw_pass(
                 render_buffer,
-                scale,
+                sample_buffer,
                 &shaders.down,
+                damage.downscale(1 << i),
                 half_pixel,
-                blur_config,
-                damage,
             )?;
             fx_buffers.current_buffer.swap();
         }
@@ -710,30 +602,43 @@ pub(super) unsafe fn get_main_buffer_blur(
         ];
         for i in 0..passes {
             let (sample_buffer, render_buffer) = fx_buffers.buffers();
-            let damage = dst_expanded.downscale(1 << (passes - 1 - i));
-            render_blur_pass_with_gl(
-                gl,
-                vbos,
-                debug,
-                supports_instancing,
-                projection_matrix,
-                sample_buffer,
+            draw_pass(
                 render_buffer,
-                scale,
+                sample_buffer,
                 &shaders.up,
+                damage.downscale(1 << passes - i - 1),
                 half_pixel,
-                blur_config,
-                damage,
             )?;
             fx_buffers.current_buffer.swap();
         }
-    }
 
-    // Cleanup
-    {
-        gl.DeleteFramebuffers(1, &mut sample_fbo as *mut _);
+        // Cleanup before returning texture
         gl.BindFramebuffer(ffi::FRAMEBUFFER, prev_fbo as u32);
+
+        Result::<_, GlesError>::Ok(fx_buffers.effects.clone())
+    })??;
+
+    Ok(blurred_buffer)
+}
+
+/// Create a framebuffer object for a given [`GlesTexture`] used to bind that texture.
+unsafe fn create_texture_fbo(gl: &ffi::Gles2, texture: &GlesTexture) -> Result<u32, GlesError> {
+    let mut fbo = 0;
+    gl.GenFramebuffers(1, &mut fbo as _);
+    gl.BindFramebuffer(ffi::DRAW_FRAMEBUFFER, fbo);
+    gl.FramebufferTexture2D(
+        ffi::FRAMEBUFFER,
+        ffi::COLOR_ATTACHMENT0,
+        ffi::TEXTURE_2D,
+        texture.tex_id(),
+        0,
+    );
+    gl.Clear(ffi::COLOR_BUFFER_BIT);
+    let status = gl.CheckFramebufferStatus(ffi::FRAMEBUFFER);
+    if status != ffi::FRAMEBUFFER_COMPLETE {
+        gl.DeleteFramebuffers(1, &mut fbo as _);
+        return Err(GlesError::FramebufferBindingError);
     }
 
-    Ok(fx_buffers.effects.clone())
+    Ok(fbo)
 }

--- a/src/renderer/blur/shader.rs
+++ b/src/renderer/blur/shader.rs
@@ -5,9 +5,6 @@
 //! NOTE: Since we are assured that this shader lives as long as the compositor does, there's no
 //! need to add a destruction callback sender like smithay does.
 
-use std::fmt::Write;
-use std::sync::Arc;
-
 use smithay::backend::renderer::gles::{ffi, link_program, GlesError, GlesRenderer};
 
 use crate::renderer::shaders::{BLUR_DOWN_SRC, BLUR_UP_SRC, VERTEX_SRC};
@@ -29,141 +26,41 @@ impl BlurShaders {
     }
 }
 
-#[derive(Clone, Debug)]
-pub(crate) struct BlurShader(Arc<[BlurShaderVariant; 2]>);
 impl BlurShader {
-    pub(super) fn variant_for_format(
-        &self,
-        format: Option<ffi::types::GLenum>,
-        has_alpha: bool,
-    ) -> &BlurShaderVariant {
-        match format {
-            Some(ffi::BGRA_EXT) | Some(ffi::RGBA) | Some(ffi::RGBA8) | Some(ffi::RGB10_A2)
-            | Some(ffi::RGBA16F) => {
-                if has_alpha {
-                    &self.0[0]
-                } else {
-                    &self.0[1]
-                }
-            }
-            // SAFETY: Since we create the blur textures ourselves (through
-            // Offscreen::create_buffer) they should always be local to the renderer
-            None => panic!("Blur textures should not be external!"),
-            _ => panic!("Unknown texture type"),
-        }
-    }
+    pub(super) unsafe fn compile(gl: &ffi::Gles2, shader: &str) -> Result<Self, GlesError> {
+        let program = unsafe { link_program(gl, VERTEX_SRC, &shader)? };
 
-    pub(super) unsafe fn compile(gl: &ffi::Gles2, src: &str) -> Result<Self, GlesError> {
-        let create_variant = |defines: &[&str]| -> Result<BlurShaderVariant, GlesError> {
-            let shader = src.replace(
-                "//_DEFINES_",
-                &defines.iter().fold(String::new(), |mut shader, define| {
-                    let _ = writeln!(&mut shader, "#define {}", define);
-                    shader
-                }),
-            );
-            let debug_shader = src.replace(
-                "//_DEFINES_",
-                &defines.iter().chain(&["DEBUG_FLAGS"]).fold(
-                    String::new(),
-                    |mut shader, define| {
-                        let _ = writeln!(shader, "#define {}", define);
-                        shader
-                    },
-                ),
-            );
+        let vert = c"vert";
+        let vert_position = c"vert_position";
+        let tex = c"tex";
+        let matrix = c"matrix";
+        let tex_matrix = c"tex_matrix";
+        let alpha = c"alpha";
+        let radius = c"radius";
+        let half_pixel = c"half_pixel";
 
-            let program = unsafe { link_program(gl, VERTEX_SRC, &shader)? };
-            let debug_program = unsafe { link_program(gl, VERTEX_SRC, debug_shader.as_ref())? };
-
-            let vert = c"vert";
-            let vert_position = c"vert_position";
-            let tex = c"tex";
-            let matrix = c"matrix";
-            let tex_matrix = c"tex_matrix";
-            let alpha = c"alpha";
-            let radius = c"radius";
-            let half_pixel = c"half_pixel";
-
-            Ok(BlurShaderVariant {
-                normal: BlurShaderProgram {
-                    program,
-                    uniform_tex: gl
-                        .GetUniformLocation(program, tex.as_ptr() as *const ffi::types::GLchar),
-                    uniform_matrix: gl
-                        .GetUniformLocation(program, matrix.as_ptr() as *const ffi::types::GLchar),
-                    uniform_tex_matrix: gl.GetUniformLocation(
-                        program,
-                        tex_matrix.as_ptr() as *const ffi::types::GLchar,
-                    ),
-                    uniform_alpha: gl
-                        .GetUniformLocation(program, alpha.as_ptr() as *const ffi::types::GLchar),
-                    uniform_radius: gl
-                        .GetUniformLocation(program, radius.as_ptr() as *const ffi::types::GLchar),
-                    uniform_half_pixel: gl.GetUniformLocation(
-                        program,
-                        half_pixel.as_ptr() as *const ffi::types::GLchar,
-                    ),
-                    attrib_vert: gl
-                        .GetAttribLocation(program, vert.as_ptr() as *const ffi::types::GLchar),
-                    attrib_vert_position: gl.GetAttribLocation(
-                        program,
-                        vert_position.as_ptr() as *const ffi::types::GLchar,
-                    ),
-                },
-                debug: BlurShaderProgram {
-                    program: debug_program,
-                    uniform_tex: gl.GetUniformLocation(
-                        debug_program,
-                        tex.as_ptr() as *const ffi::types::GLchar,
-                    ),
-                    uniform_matrix: gl.GetUniformLocation(
-                        debug_program,
-                        matrix.as_ptr() as *const ffi::types::GLchar,
-                    ),
-                    uniform_tex_matrix: gl.GetUniformLocation(
-                        debug_program,
-                        tex_matrix.as_ptr() as *const ffi::types::GLchar,
-                    ),
-                    uniform_alpha: gl.GetUniformLocation(
-                        debug_program,
-                        alpha.as_ptr() as *const ffi::types::GLchar,
-                    ),
-                    uniform_radius: gl.GetUniformLocation(
-                        debug_program,
-                        radius.as_ptr() as *const ffi::types::GLchar,
-                    ),
-                    uniform_half_pixel: gl.GetUniformLocation(
-                        debug_program,
-                        half_pixel.as_ptr() as *const ffi::types::GLchar,
-                    ),
-                    attrib_vert: gl.GetAttribLocation(
-                        debug_program,
-                        vert.as_ptr() as *const ffi::types::GLchar,
-                    ),
-                    attrib_vert_position: gl.GetAttribLocation(
-                        debug_program,
-                        vert_position.as_ptr() as *const ffi::types::GLchar,
-                    ),
-                },
-            })
-        };
-
-        Ok(BlurShader(Arc::new([
-            create_variant(&[])?,
-            create_variant(&["NO_ALPHA"])?,
-        ])))
+        Ok(Self {
+            program,
+            uniform_tex: gl.GetUniformLocation(program, tex.as_ptr() as *const ffi::types::GLchar),
+            uniform_matrix: gl
+                .GetUniformLocation(program, matrix.as_ptr() as *const ffi::types::GLchar),
+            uniform_tex_matrix: gl
+                .GetUniformLocation(program, tex_matrix.as_ptr() as *const ffi::types::GLchar),
+            uniform_alpha: gl
+                .GetUniformLocation(program, alpha.as_ptr() as *const ffi::types::GLchar),
+            uniform_radius: gl
+                .GetUniformLocation(program, radius.as_ptr() as *const ffi::types::GLchar),
+            uniform_half_pixel: gl
+                .GetUniformLocation(program, half_pixel.as_ptr() as *const ffi::types::GLchar),
+            attrib_vert: gl.GetAttribLocation(program, vert.as_ptr() as *const ffi::types::GLchar),
+            attrib_vert_position: gl
+                .GetAttribLocation(program, vert_position.as_ptr() as *const ffi::types::GLchar),
+        })
     }
 }
 
 #[derive(Clone, Debug)]
-pub struct BlurShaderVariant {
-    pub(super) normal: BlurShaderProgram,
-    pub(super) debug: BlurShaderProgram,
-}
-
-#[derive(Copy, Clone, Debug)]
-pub struct BlurShaderProgram {
+pub struct BlurShader {
     pub(super) program: ffi::types::GLuint,
     pub(super) uniform_tex: ffi::types::GLint,
     pub(super) uniform_tex_matrix: ffi::types::GLint,


### PR DESCRIPTION
The first blur implementation that was added in e75c77d1b8f0f78362021c202a642e7f26f6fc1c while was working, is still quite _naive_ to say the least. This PR aims to address the flaws regarding it.

- [ ] The current blur implementation breaks with output scaling
- [ ] Damage tracking is currently not being taken into account, causing a lot of lost GPU performance
- [ ] The `winit-backend` breaks really bad with true blur implementation, since we are unable to make winit's `EGLSurface` current after running blur operations, since its private.
- [ ] Performance? As Yalter pointed out, having [Tracy GPU profiling](https://github.com/Smithay/smithay/pull/1134) would be really helpful to know how efficient this implementation is, but currently *seems* to be fine.

A lot of the blur logic will also be simplified, since a lot of boilerplate code was copied from Smithay to get started, which handled more general stuff.