### PR TITLE
fix(nix): eval with `allowAliases = false`

### DIFF
--- a/nix/hm-module.nix
+++ b/nix/hm-module.nix
@@ -10,7 +10,7 @@
       pkgs,
       ...
     }: let
-      inherit (self.packages.${pkgs.system}) fht-compositor;
+      inherit (self.packages.${pkgs.stdenv.hostPlatform.system}) fht-compositor;
       cfg = config.programs.fht-compositor;
       tomlFormat = pkgs.formats.toml {};
 

--- a/nix/nixos-module.nix
+++ b/nix/nixos-module.nix
@@ -12,7 +12,7 @@
       pkgs,
       ...
     }: let
-      inherit (pkgs) system;
+      inherit (pkgs.stdenv.hostPlatform) system;
       cfg = config.programs.fht-compositor;
       inherit (self.packages.${system}) fht-compositor fht-share-picker;
 


### PR DESCRIPTION
does as title; this is also how nixpkgs mange's `system` to keep it clear what its for.