### PR TITLE
Binary Space Partitioning

### DIFF
--- a/docs/configuration/animations.md
+++ b/docs/configuration/animations.md
@@ -39,11 +39,11 @@ The last kind of curves we support are spring curves. They use a physical model 
 [libadwaita's `SpringAnimation`](https://gnome.pages.gitlab.gnome.org/libadwaita/doc/1.3/class.SpringAnimation.html).
 
 Since they are much more tweakable, you'd rather use something like [Elastic](https://apps.gnome.org/Elastic/) to tweak
-the parameters yourself, and get a preview of what the curve will look like, aswell as the total animation time.
+the parameters yourself, and get a preview of what the curve will look like, as well as the total animation time.
 
 ![Elastic window](/assets/elastic.png)
 
-Note however that you should be conservative with the valuess you pass into this animation, as it can *really quickly* cause
+Note however that you should be conservative with the values you pass into this animation, as it can *really quickly* cause
 values to overshoot/undershoot to infinity, and potentially causing crashes (integer overflows).
 
 ```toml

--- a/docs/configuration/decorations.md
+++ b/docs/configuration/decorations.md
@@ -9,7 +9,7 @@ still enhance the looks of the desktop session
 ## Borders
 
 Borders are an outline drawn around windows in a workspace. The focused window will get a different border color to indicate that it is focused and that
-it has active keyboard focus. Borders can also apply rounded corner radius aroud windows.
+it has active keyboard focus. Borders can also apply rounded corner radius around windows.
 
 #### `border.focused-color`, `border.normal-color`
 
@@ -78,7 +78,7 @@ though nothing stops you from using high number of passes with low blur values, 
 
 > [!CAUTION]
 > Higher blur passes will cause more rendering to happen, and thus put more strain on your GPU. It is recommended to keep this value below
-> 3 or 4, because otherwise it will *kill* your performance and framerates
+> 3 or 4, because otherwise it will *kill* your performance and frame rates
 
 ---
 

--- a/docs/configuration/input.md
+++ b/docs/configuration/input.md
@@ -21,7 +21,7 @@ By default, all these are empty strings (using system defaults), and layout is `
 
 #### `repeat-rate`, `repeat-delay`
 
-These two options control key repeating. `repeat-delay` is the delay in milliseconds that you should hown a key for key repeating to
+These two options control key repeating. `repeat-delay` is the delay in milliseconds that you should hold down a key for repeating to
 start. `repeat-rate` is the frequency at which the key is repeated.
 
 Default settings are `repeat-rate=25`, `repeat-delay=250`
@@ -76,7 +76,7 @@ For touchpads, determines how to emulate a scroll wheel using only your fingers 
 #### `scroll-button`, `scroll-button-lock`
 
 The button used to enable `on-button-down` scroll method. When `scroll-button-lock` is enabled, the button does not need to be held
-down, and insteads turns the button into a toggle switch.
+down, and instead turns the button into a toggle switch.
 
 ---
 

--- a/docs/configuration/introduction.md
+++ b/docs/configuration/introduction.md
@@ -33,7 +33,7 @@ The configuration is live-reloaded. You can edit and save the file and `fht-comp
 apply changes.
 
 If you made a mistake when writing your configuration (let that be syntax, invalid values, unknown enum variant, etc.), the
-compositor will warn you with a popup window sliding from the top of your screen. You can run `fht-comopsitor check-configuration`
+compositor will warn you with a pop-up window sliding from the top of your screen. You can run `fht-comopsitor check-configuration`
 to get that error in your terminal.
 
 
@@ -42,7 +42,7 @@ to get that error in your terminal.
 ##### `autostart`
 
 Command lines to run whenever the compositor starts up. Each line is evaluated using `/bin/sh -c "<command line>"`, meaning you have
-access to shell-expansions like using variables, or exapding of `~` to `$HOME`
+access to shell-expansions like using variables, or expanding of `~` to `$HOME`
 
 > [!TIP] Autostart with systemd units
 > While using this approach for autostart can work, using systemd user services are a much better! You benefit from having
@@ -62,7 +62,7 @@ access to shell-expansions like using variables, or exapding of `~` to `$HOME`
 
 ##### `env`
 
-Environment variables to set. They are set before anything else starts up in the compositor, and before `autostart` is exxecuted
+Environment variables to set. They are set before anything else starts up in the compositor, and before `autostart` is executed
 
 ```toml
 [env]

--- a/docs/configuration/keybindings.md
+++ b/docs/configuration/keybindings.md
@@ -175,7 +175,7 @@ Swaps the currently focused window with next/previous window in the workspace. R
 
 #### `focus-next-output`, `focus-previous-output`
 
-Focus the next/previous output in the gloabl space. Outputs are ordered by the way they got detected/inserted.
+Focus the next/previous output in the global space. Outputs are ordered by the way they got detected/inserted.
 
 ---
 

--- a/docs/usage/layouts.md
+++ b/docs/usage/layouts.md
@@ -50,7 +50,7 @@ Dynamic layouts are extremely flexible and can be molded to adapt for any situat
 fuss creating a specialized layout for your current job in other window management models like Sway's or River's, instead, you
 pick a layout that suits your need, resize and move some window around, and start working.
 
-You can create workflows and make them work with what you have to do quickly, and adapt for some unforseen cases or patterns
+You can create workflows and make them work with what you have to do quickly, and adapt for some unforeseen cases or patterns
 the main task has. You can build from the provided layouts and get started working.
 
 Overall, the experience is very natural and you'll get the hang of it really fast.

--- a/docs/usage/workspaces.md
+++ b/docs/usage/workspaces.md
@@ -16,7 +16,7 @@ instead you move individual windows from/to workspaces or outputs.
 
 ## Advantages of this system
 
-Windows are organized in a predictible fashion, and you have full knowledge and control on where they are and where they go.
+Windows are organized in a predictable fashion, and you have full knowledge and control on where they are and where they go.
 Workspaces are always available for window rules and custom scripts (for example to create scratchpad workspaces).
 
 ## Example workflow
@@ -27,7 +27,7 @@ I am currently *working* on), second is for the web browser, third is for chat c
 Fractal, etc.) sixth is for video games, etc.
 
 This streamlined workflow allows me to switch working context **very** fast using keybinds, since I have keybinds
-engrained in my mind, I can switly get to my browser to search up documentation, quickly respond to a notification from
+engrained in my mind, I can swiftly get to my browser to search up documentation, quickly respond to a notification from
 a chat client, and more.
 
 If you want, you can even disable [animations](/configuration/animations) to make this even more immediate.

--- a/fht-compositor-config/src/lib.rs
+++ b/fht-compositor-config/src/lib.rs
@@ -603,6 +603,7 @@ pub enum WorkspaceLayout {
     Tile,
     BottomStack,
     CenteredMaster,
+    BinarySpacePartition,
     Floating,
 }
 
@@ -613,6 +614,8 @@ pub enum InsertWindowStrategy {
     EndOfSlaveStack,
     ReplaceMaster,
     AfterFocused,
+    LongestSide,
+    Spiral,
 }
 
 fn default_cursor_theme() -> String {

--- a/fht-compositor-config/src/lib.rs
+++ b/fht-compositor-config/src/lib.rs
@@ -614,8 +614,6 @@ pub enum InsertWindowStrategy {
     EndOfSlaveStack,
     ReplaceMaster,
     AfterFocused,
-    LongestSide,
-    Spiral,
 }
 
 fn default_cursor_theme() -> String {

--- a/fht-compositor-config/src/lib.rs
+++ b/fht-compositor-config/src/lib.rs
@@ -603,7 +603,8 @@ pub enum WorkspaceLayout {
     Tile,
     BottomStack,
     CenteredMaster,
-    BinarySpacePartition,
+    BinaryTree,
+    SpiralTree,
     Floating,
 }
 

--- a/src/space/bsp.rs
+++ b/src/space/bsp.rs
@@ -1,0 +1,194 @@
+use smithay::utils::{Logical, Rectangle};
+
+#[derive(Debug)]
+pub enum Split {
+    Horizontal,
+    Vertical
+}
+
+/// A BSP Tree Node can either have zero or two children.
+#[derive(Debug)]
+pub struct BspNode {
+    pub rect: Rectangle<i32, Logical>,
+    pub split: Split,
+    pub first_child: Option<usize>,
+    pub second_child: Option<usize>,
+    pub parent: Option<usize>,
+}
+
+#[derive(Debug)]
+pub struct BspTree {
+    pub arena: Vec<BspNode>,
+    pub leaves: usize,
+}
+
+impl BspNode {
+    pub fn new(rect: Rectangle<i32, Logical>, split: Split, parent: Option<usize>) -> BspNode {
+        BspNode {
+            rect,
+            split,
+            first_child: None,
+            second_child: None,
+            parent
+        }
+    }
+
+    pub fn is_leaf(&self) -> bool {
+        self.first_child.is_none() && self.second_child.is_none()
+    }
+}
+
+impl BspTree {
+    pub fn new(rect: Rectangle<i32, Logical>, len: usize) -> Self {
+        let root = BspNode::new(rect, Split::Horizontal, None);
+
+        let mut arena = Vec::with_capacity(len);
+        arena.push(root);
+
+        BspTree {
+            arena,
+            leaves: 1,
+        }
+    }
+
+    pub fn add_child(&mut self, node: BspNode) -> usize {
+        let idx = self.arena.len();
+        if let Some(parent) = node.parent {
+            if self.arena[parent].first_child.is_none() {
+                self.arena[parent].first_child = Some(idx);
+            } else if self.arena[parent].second_child.is_none() {
+                self.arena[parent].second_child = Some(idx);
+            }
+        }
+        self.arena.push(node);
+
+        idx
+    }
+}
+
+pub fn build_tree(tree: &mut BspTree, idx: usize, len: usize, split_ratio: f64, inner_gaps: i32) {
+    if tree.arena[idx].is_leaf() && tree.leaves < len {
+        let mut first_rect = tree.arena[idx].rect;
+        let mut second_rect = tree.arena[idx].rect;
+        let mut first_split = Split::Vertical;
+        let mut second_split = Split::Vertical;
+
+        match tree.arena[idx].split {
+            Split::Horizontal => {
+                let nh = (tree.arena[idx].rect.size.h as f64 * split_ratio) as i32 - (inner_gaps / 2);
+                let nly = tree.arena[idx].rect.loc.y + nh + inner_gaps;
+                first_rect.size = (first_rect.size.w, nh).into();
+                second_rect.size = (second_rect.size.w, nh).into();
+                second_rect.loc = (second_rect.loc.x, nly).into();
+            }
+            Split::Vertical => {
+                let nw = (tree.arena[idx].rect.size.w as f64 * split_ratio) as i32 - (inner_gaps / 2);
+                let nlx = tree.arena[idx].rect.loc.x + nw + inner_gaps;
+                first_rect.size = (nw, first_rect.size.h).into();
+                second_rect.size = (nw, second_rect.size.h).into();
+                second_rect.loc = (nlx, second_rect.loc.y).into();
+
+                first_split = Split::Horizontal;
+                second_split = Split::Horizontal;
+            }
+        }
+        
+        let first_child = BspNode::new(first_rect, first_split, Some(idx));
+        let second_child = BspNode::new(second_rect, second_split, Some(idx));
+
+        let _ = tree.add_child(first_child);
+        let second_idx = tree.add_child(second_child);
+
+        // We're technically adding two leaves, but then we iterate into another branch in the
+        // `build_tree` call, so it's plus two, minus one
+        tree.leaves += 1;
+
+        build_tree(tree, second_idx, len, split_ratio, inner_gaps); 
+    } else {
+        return;
+    }
+}
+
+pub fn to_leaves(tree: &mut BspTree, root: usize, leaves: &mut Vec<Rectangle<i32, Logical>>) {
+    if tree.arena[root].is_leaf() {
+        leaves.push(tree.arena[root].rect);
+    } else {
+        if let Some(first) = tree.arena[root].first_child {
+            to_leaves(tree, first, leaves);
+        }
+        if let Some(second) = tree.arena[root].second_child {
+            to_leaves(tree, second, leaves);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn correct_sizes() {
+        let mut tree = BspTree::new(Rectangle::new((0, 0).into(), (100, 100).into()), 4);
+        let mut leaves = Vec::new();
+        build_tree(&mut tree, 0, 4, 0.5, 0);
+        to_leaves(&mut tree, 0, &mut leaves);
+
+        assert_eq!(leaves[0].size.w, 100);
+        assert_eq!(leaves[0].size.h, 50);
+
+        assert_eq!(leaves[1].size.w, 50);
+        assert_eq!(leaves[1].size.h, 50);
+
+        assert_eq!(leaves[2].size.w, 50);
+        assert_eq!(leaves[2].size.h, 25);
+
+        assert_eq!(leaves[3].size.w, 50);
+        assert_eq!(leaves[3].size.h, 25);
+        
+        assert_eq!(leaves[0].loc.x, 0);
+        assert_eq!(leaves[0].loc.y, 0);
+
+        assert_eq!(leaves[1].loc.x, 0);
+        assert_eq!(leaves[1].loc.y, 50);
+
+        assert_eq!(leaves[2].loc.x, 50);
+        assert_eq!(leaves[2].loc.y, 50);
+
+        assert_eq!(leaves[3].loc.x, 50);
+        assert_eq!(leaves[3].loc.y, 75);
+    }
+
+    #[test]
+    fn correct_sizes_with_gaps() {
+        let mut tree = BspTree::new(Rectangle::new((0, 0).into(), (100, 100).into()), 4);
+        let mut leaves = Vec::new();
+        build_tree(&mut tree, 0, 4, 0.5, 4);
+        to_leaves(&mut tree, 0, &mut leaves);
+
+        dbg!(&tree);
+
+        assert_eq!(leaves[0].size.w, 100);
+        assert_eq!(leaves[0].size.h, 48);
+        
+        assert_eq!(leaves[1].size.w, 48);
+        assert_eq!(leaves[1].size.h, 48);
+        
+        assert_eq!(leaves[2].size.w, 48);
+        assert_eq!(leaves[2].size.h, 22);
+        
+        assert_eq!(leaves[3].size.w, 48);
+        assert_eq!(leaves[3].size.h, 22);
+        
+        assert_eq!(leaves[0].loc.x, 0);
+        assert_eq!(leaves[0].loc.y, 0);
+        
+        assert_eq!(leaves[1].loc.x, 0);
+        assert_eq!(leaves[1].loc.y, 52);
+        
+        assert_eq!(leaves[2].loc.x, 52);
+        assert_eq!(leaves[2].loc.y, 52);
+        
+        assert_eq!(leaves[3].loc.x, 52);
+        assert_eq!(leaves[3].loc.y, 78);
+    }
+}

--- a/src/space/mod.rs
+++ b/src/space/mod.rs
@@ -32,6 +32,7 @@ use crate::utils::RectCenterExt;
 use crate::window::Window;
 
 mod border;
+mod bsp;
 mod closing_tile;
 mod monitor;
 pub mod shadow;

--- a/src/space/mod.rs
+++ b/src/space/mod.rs
@@ -32,7 +32,7 @@ use crate::utils::RectCenterExt;
 use crate::window::Window;
 
 mod border;
-mod bsp;
+mod tree;
 mod closing_tile;
 mod monitor;
 pub mod shadow;

--- a/src/space/tree.rs
+++ b/src/space/tree.rs
@@ -1,5 +1,7 @@
 use smithay::utils::{Logical, Rectangle};
 
+use fht_compositor_config::WorkspaceLayout;
+
 #[derive(Debug)]
 pub enum Split {
     Horizontal,
@@ -8,7 +10,7 @@ pub enum Split {
 
 /// A BSP Tree Node can either have zero or two children.
 #[derive(Debug)]
-pub struct BspNode {
+pub struct Node {
     pub rect: Rectangle<i32, Logical>,
     pub split: Split,
     pub first_child: Option<usize>,
@@ -17,15 +19,16 @@ pub struct BspNode {
 }
 
 #[derive(Debug)]
-pub struct BspTree {
-    pub arena: Vec<BspNode>,
+pub struct Tree {
+    pub arena: Vec<Node>,
     pub leaves: usize,
+    layout: WorkspaceLayout,
     inner_gaps: i32,
 }
 
-impl BspNode {
-    pub fn new(rect: Rectangle<i32, Logical>, split: Split, parent: Option<usize>) -> BspNode {
-        BspNode {
+impl Node {
+    pub fn new(rect: Rectangle<i32, Logical>, split: Split, parent: Option<usize>) -> Node {
+        Node {
             rect,
             split,
             first_child: None,
@@ -39,21 +42,22 @@ impl BspNode {
     }
 }
 
-impl BspTree {
-    pub fn new(rect: Rectangle<i32, Logical>, len: usize, inner_gaps: i32) -> Self {
-        let root = BspNode::new(rect, Split::Horizontal, None);
+impl Tree {
+    pub fn new(layout: WorkspaceLayout, rect: Rectangle<i32, Logical>, len: usize, inner_gaps: i32) -> Self {
+        let root = Node::new(rect, Split::Horizontal, None);
 
         let mut arena = Vec::with_capacity(len);
         arena.push(root);
 
-        BspTree {
+        Tree {
             arena,
             leaves: 1,
+            layout,
             inner_gaps,
         }
     }
 
-    pub fn add_child(&mut self, node: BspNode) -> usize {
+    pub fn add_child(&mut self, node: Node) -> usize {
         let idx = self.arena.len();
         if let Some(parent) = node.parent {
             if self.arena[parent].first_child.is_none() {
@@ -78,51 +82,61 @@ impl BspTree {
                 Split::Horizontal => {
                     let nh = (self.arena[idx].rect.size.h as f64 * split_ratio) as i32
                         - (self.inner_gaps / 2);
-                    let nly = self.arena[idx].rect.loc.y + nh + self.inner_gaps;
                     first_rect.size = (first_rect.size.w, nh).into();
                     second_rect.size = (second_rect.size.w, nh).into();
-                    second_rect.loc = (second_rect.loc.x, nly).into();
+                    let nly = self.arena[idx].rect.loc.y + nh + self.inner_gaps;
+
+                    if self.leaves % 4 == 3 && self.layout == WorkspaceLayout::SpiralTree {
+                        first_rect.loc = (first_rect.loc.x, nly).into();
+                    } else {
+                        second_rect.loc = (second_rect.loc.x, nly).into();
+                    }
                 }
                 Split::Vertical => {
                     let nw = (self.arena[idx].rect.size.w as f64 * split_ratio) as i32
                         - (self.inner_gaps / 2);
-                    let nlx = self.arena[idx].rect.loc.x + nw + self.inner_gaps;
                     first_rect.size = (nw, first_rect.size.h).into();
                     second_rect.size = (nw, second_rect.size.h).into();
-                    second_rect.loc = (nlx, second_rect.loc.y).into();
+                    let nlx = self.arena[idx].rect.loc.x + nw + self.inner_gaps;
+
+                    if self.leaves % 4 == 2 && self.layout == WorkspaceLayout::SpiralTree {
+                        first_rect.loc = (nlx, first_rect.loc.y).into();
+                    } else {
+                        second_rect.loc = (nlx, second_rect.loc.y).into();
+                    }
 
                     first_split = Split::Horizontal;
                     second_split = Split::Horizontal;
                 }
             }
 
-            let first_child = BspNode::new(first_rect, first_split, Some(idx));
-            let second_child = BspNode::new(second_rect, second_split, Some(idx));
+            let first_child = Node::new(first_rect, first_split, Some(idx));
+            let second_child = Node::new(second_rect, second_split, Some(idx));
 
             let _ = self.add_child(first_child);
-            let second_idx = self.add_child(second_child);
-
+            let n_idx = self.add_child(second_child);
+            
             // We're technically adding two leaves, but then we iterate into another branch in the
             // `build_tree` call, so it's plus two, minus one
             self.leaves += 1;
 
-            self.grow(second_idx, len, split_ratio);
+            self.grow(n_idx, len, split_ratio);
         } else {
             return;
         }
     }
 
-    pub fn leaves(&mut self, root: usize) -> Vec<Rectangle<i32, Logical>> {
+    pub fn into_leaves(&mut self, root: usize) -> Vec<Rectangle<i32, Logical>> {
         let mut leaves = Vec::new();
 
         if self.arena[root].is_leaf() {
             leaves.push(self.arena[root].rect);
         } else {
             if let Some(first) = self.arena[root].first_child {
-                leaves.append(&mut self.leaves(first));
+                leaves.append(&mut self.into_leaves(first));
             }
             if let Some(second) = self.arena[root].second_child {
-                leaves.append(&mut self.leaves(second));
+                leaves.append(&mut self.into_leaves(second));
             }
         }
 
@@ -136,9 +150,9 @@ mod tests {
 
     #[test]
     fn correct_sizes() {
-        let mut tree = BspTree::new(Rectangle::new((0, 0).into(), (100, 100).into()), 4, 0);
+        let mut tree = Tree::new(WorkspaceLayout::BinaryTree, Rectangle::new((0, 0).into(), (100, 100).into()), 4, 0);
         tree.grow(0, 4, 0.5);
-        let leaves = tree.leaves(0);
+        let leaves = tree.into_leaves(0);
 
         assert_eq!(leaves[0].size.w, 100);
         assert_eq!(leaves[0].size.h, 50);
@@ -166,12 +180,32 @@ mod tests {
     }
 
     #[test]
-    fn correct_sizes_with_gaps() {
-        let mut tree = BspTree::new(Rectangle::new((0, 0).into(), (100, 100).into()), 4, 4);
-        tree.grow(0, 4, 0.5);
-        let leaves = tree.leaves(0);
+    fn correct_locs_for_spiral() {
+        let mut tree = Tree::new(WorkspaceLayout::SpiralTree, Rectangle::new((0, 0).into(), (100, 100).into()), 4, 0);
+        tree.grow(0, 5, 0.5);
+        let leaves = tree.into_leaves(0);
 
-        dbg!(&tree);
+        assert_eq!(leaves[0].loc.x, 0);
+        assert_eq!(leaves[0].loc.y, 0);
+
+        assert_eq!(leaves[1].loc.x, 50);
+        assert_eq!(leaves[1].loc.y, 50);
+
+        assert_eq!(leaves[2].loc.x, 0);
+        assert_eq!(leaves[2].loc.y, 75);
+
+        assert_eq!(leaves[3].loc.x, 0);
+        assert_eq!(leaves[3].loc.y, 50);
+
+        assert_eq!(leaves[4].loc.x, 25);
+        assert_eq!(leaves[4].loc.y, 50);
+    }
+
+    #[test]
+    fn correct_sizes_with_gaps() {
+        let mut tree = Tree::new(WorkspaceLayout::BinaryTree, Rectangle::new((0, 0).into(), (100, 100).into()), 4, 4);
+        tree.grow(0, 4, 0.5);
+        let leaves = tree.into_leaves(0);
 
         assert_eq!(leaves[0].size.w, 100);
         assert_eq!(leaves[0].size.h, 48);

--- a/src/space/workspace.rs
+++ b/src/space/workspace.rs
@@ -1701,12 +1701,14 @@ impl Workspace {
                 };
 
                 let stack_heights = {
-                    let proportions = binary_space_proportion_heights((tiles_len - nmaster) as usize);
+                    let proportions =
+                        binary_space_proportion_heights((tiles_len - nmaster) as usize);
                     binary_space_lengths(&proportions, master_geo.size.h)
                 };
 
                 let stack_widths = {
-                    let proportions = binary_space_proportion_widths((tiles_len - nmaster) as usize);
+                    let proportions =
+                        binary_space_proportion_widths((tiles_len - nmaster) as usize);
                     binary_space_lengths(&proportions, master_geo.size.w)
                 };
 
@@ -2194,7 +2196,7 @@ mod tests {
         assert_eq!(propo4, vec![0.5, 0.5, 0.25, 0.25]);
         assert_eq!(propo6, vec![0.5, 0.5, 0.25, 0.25, 0.125, 0.125]);
     }
-    
+
     #[test]
     fn binary_space_correct_widths() {
         let len1: usize = 1;

--- a/src/space/workspace.rs
+++ b/src/space/workspace.rs
@@ -596,6 +596,8 @@ impl Workspace {
                         active_idx
                     }
                 }
+                InsertWindowStrategy::LongestSide => todo!(),
+                InsertWindowStrategy::Spiral => todo!(),
             }
         };
         if self.config.focus_new_windows {
@@ -826,6 +828,7 @@ impl Workspace {
 
                 self.arrange_tiles(true);
             }
+            WorkspaceLayout::BinarySpacePartition => todo!(),
             WorkspaceLayout::Floating => {
                 // Just insert it, who cares really.
                 self.tiles.push(tile);
@@ -1156,6 +1159,8 @@ impl Workspace {
                     active_idx
                 }
             }
+            InsertWindowStrategy::LongestSide => todo!(),
+            InsertWindowStrategy::Spiral => todo!(),
         };
 
         let tiles_len =
@@ -1341,6 +1346,7 @@ impl Workspace {
                     }
                 }
             }
+            WorkspaceLayout::BinarySpacePartition => todo!(),
             WorkspaceLayout::Floating => {}
         }
     }
@@ -1602,6 +1608,7 @@ impl Workspace {
                     right_geo.loc.y += height + inner_gaps;
                 }
             }
+            WorkspaceLayout::BinarySpacePartition => todo!(),
             WorkspaceLayout::Floating => {}
         }
     }

--- a/src/space/workspace.rs
+++ b/src/space/workspace.rs
@@ -1729,7 +1729,7 @@ impl Workspace {
                             Rectangle::new(stack_geo.loc, (stack_width, stack_height).into());
                         tile.set_geometry(new_geo, animate);
 
-                        if idx % 2 == 1 {
+                        if (nmaster as usize - idx) % 2 == 1 {
                             stack_geo.loc.x += stack_width + inner_gaps;
                         }
                         stack_geo.loc.y += stack_height + inner_gaps;

--- a/src/space/workspace.rs
+++ b/src/space/workspace.rs
@@ -1732,9 +1732,11 @@ impl Workspace {
                         tile.set_geometry(new_geo, animate);
 
                         if (nmaster as usize - idx) % 2 == 1 {
-                            stack_geo.loc.x += stack_width + inner_gaps;
+                            stack_geo.loc.x += stack_width + (inner_gaps / 2);
                         }
-                        stack_geo.loc.y += stack_height + inner_gaps;
+                        if (nmaster as usize - idx) % 2 == 0 {
+                            stack_geo.loc.y += stack_height + (inner_gaps / 2);
+                        }
                     }
                 }
             }
@@ -2170,8 +2172,9 @@ fn proportion_length(proportions: &[f64], length: i32) -> Vec<i32> {
 }
 
 /// Returns a vector containing the calculated proportional lengths
+///
+/// This function ensures that the returned lengths' sum is equal to `length`
 fn binary_space_lengths(proportions: &[f64], length: i32) -> Vec<i32> {
-    // Probably will need to find a better way to guarantee lengths for binary space partitioning
     proportions
         .iter()
         .map(|&cfact| (length as f64 * cfact).floor() as i32)


### PR DESCRIPTION
Hi! I really like the compositor. I noticed there was an open issue for adding bspwm-like partitioning to the compositor, so I gave it a shot. I have a simple implementation working on my system running Arch. There's still a bunch I need to fix, such as how it interacts with inner gaps, as well as other edge cases I'm probably not taking into account. Please feel free to comment on this or reject it! I'd like to keep working on this if you'd have me.

Here is what it looks like on my system, just punched in a bunch of terminals:
<img width="1919" height="1080" alt="image" src="https://github.com/user-attachments/assets/a9f17c34-fdf0-4e06-a949-aed9ec1c8595" />

I have this set in my `compositor.toml`:
```toml
layouts = ["tile", "floating", "binary-space-partition"]
nmaster = 1
mwfact = 0.5
inner-gaps = 5
outer-gaps = 10
```