### PR TITLE
Feat: Adding scroll mousebind handling

### DIFF
--- a/docs/configuration/mousebindings.md
+++ b/docs/configuration/mousebindings.md
@@ -1,10 +1,12 @@
 # Mousebindings
 
 These are exactly the same as [keybindings](/configuration/keybindings), expect the available mouse buttonss (instead of
-key names) are: `left`, `right`, `middle`, `right`, `forward`, `back`
+key names) are: `left`, `right`, `middle`, `right`, `forward`, `back`, `scrollup` (or `wheelup`), `scrolldown` (or `wheeldown`), `scrollleft` (or `wheelleft`), `scrollright` (or `wheelright`)
 
 ## Available mouse actions
 
 - `swap-tile`: Initiates an interactive tile swap. Allows you to grab a window and put it elsewhere in the window stack,
   move it across outputs or workspaces. For floating windows, it allows you to move them around with the mouse
 - `resize-tile`: Initiates an interactive resize. Only affects floating windows so far.
+- `focus-next-window`, `focus-previous-window`: Focused the next/previous window in the workspace. Removes the currently active fullscreen window, if any.
+- `focus-next-workspace`, `focus-previous-workspace`, I think these are clear.

--- a/fht-compositor-config/src/lib.rs
+++ b/fht-compositor-config/src/lib.rs
@@ -315,28 +315,6 @@ pub enum MouseInput {
     Axis(MouseAxis),
 }
 
-impl MouseInput {
-    pub fn from_evdev(event_type: u16, code: u16, value: i32) -> Option<Self> {
-        match (event_type, code, value) {
-            // EV_KEY = 0x01
-            (0x01, 0x110, _) => Some(MouseInput::Button(MouseButton::Left)),
-            (0x01, 0x111, _) => Some(MouseInput::Button(MouseButton::Middle)),
-            (0x01, 0x112, _) => Some(MouseInput::Button(MouseButton::Right)),
-            (0x01, 0x115, _) => Some(MouseInput::Button(MouseButton::Forward)),
-            (0x01, 0x116, _) => Some(MouseInput::Button(MouseButton::Back)),
-
-            // EV_REL = 0x02
-            // REL_WHEEL = 0x08, REL_HWHEEL = 0x06
-            (0x02, 0x08, v) if v > 0 => Some(MouseInput::Axis(MouseAxis::WheelUp)),
-            (0x02, 0x08, v) if v < 0 => Some(MouseInput::Axis(MouseAxis::WheelDown)),
-            (0x02, 0x06, v) if v > 0 => Some(MouseInput::Axis(MouseAxis::WheelRight)),
-            (0x02, 0x06, v) if v < 0 => Some(MouseInput::Axis(MouseAxis::WheelLeft)),
-
-            _ => None,
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct MousePattern(pub ModifiersState, pub MouseInput);
 

--- a/fht-compositor-config/src/lib.rs
+++ b/fht-compositor-config/src/lib.rs
@@ -332,7 +332,9 @@ impl<'de> Deserialize<'de> for MousePattern {
         for part in raw.split('-') {
             if input.is_some() {
                 // We specified something after having a button/axis, invalid
-                return Err(D::Error::custom("mouse pattern ends after the trigger"));
+                    return Err(<D::Error as serde::de::Error>::custom(
+                        "key pattern ends after the keysym",
+                    ));            
             }
 
             match part.trim() {
@@ -355,7 +357,7 @@ impl<'de> Deserialize<'de> for MousePattern {
                     "wheelleft" | "scrollleft" => input = Some(MouseInput::Axis(MouseAxis::WheelLeft)),
                     "wheelright" | "scrollright" => input = Some(MouseInput::Axis(MouseAxis::WheelRight)),
                     _ => {
-                        return Err(D::Error::invalid_value(
+                        return Err(<D::Error as serde::de::Error>::invalid_value(
                             Unexpected::Str(x),
                             &"MouseButton or MouseAxis",
                         ))
@@ -365,14 +367,10 @@ impl<'de> Deserialize<'de> for MousePattern {
         }
 
         let Some(input) = input else {
-            return Err(D::Error::missing_field("button/axis"));
+            return Err(<D::Error as serde::de::Error>::missing_field("button/axis"));
         };
 
-        let pattern = MousePattern(modifiers, input);
-
-        debug!("MousePattern parsed: {:?}", pattern);
-
-        Ok(pattern)
+        Ok(MousePattern(modifiers, input))
     }
 }
 

--- a/fht-compositor-config/src/lib.rs
+++ b/fht-compositor-config/src/lib.rs
@@ -323,8 +323,6 @@ impl<'de> Deserialize<'de> for MousePattern {
     where
         D: Deserializer<'de>,
     {
-        use serde::de::{Error, Unexpected};
-
         let raw = String::deserialize(deserializer)?;
         let mut modifiers = ModifiersState::default();
         let mut input: Option<MouseInput> = None;
@@ -400,7 +398,6 @@ pub enum MouseAction {
     FocusPreviousWindow,
     FocusNextWorkspace,
     FocusPreviousWorkspace,
-    ChangeMwfact(f64),
 }
 
 #[derive(Debug, Default, Clone, Deserialize)]

--- a/fht-compositor-config/src/lib.rs
+++ b/fht-compositor-config/src/lib.rs
@@ -332,9 +332,9 @@ impl<'de> Deserialize<'de> for MousePattern {
         for part in raw.split('-') {
             if input.is_some() {
                 // We specified something after having a button/axis, invalid
-                    return Err(<D::Error as serde::de::Error>::custom(
-                        "key pattern ends after the keysym",
-                    ));            
+                return Err(<D::Error as serde::de::Error>::custom(
+                    "key pattern ends after the keysym",
+                ));
             }
 
             match part.trim() {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -571,7 +571,54 @@ impl State {
                     .amount(Axis::Vertical)
                     .unwrap_or_else(|| vertical_amount_discrete.unwrap_or(0.0) * 3.0 / 120.0);
 
-                {
+                // Check for mouse axis bindings FIRST
+                let modifiers = self.fht.keyboard.modifier_state().into();
+                let mut handled = false;
+                
+                // Check vertical axis bindings
+                if vertical_amount > 0.0 {
+                    let mouse_pattern = fht_compositor_config::MousePattern(
+                        modifiers,
+                        fht_compositor_config::MouseInput::Axis(fht_compositor_config::MouseAxis::WheelUp),
+                    );
+                    if let Some(action) = self.fht.config.mousebinds.get(&mouse_pattern).cloned() {
+                        self.process_mouse_action(0, action, SERIAL_COUNTER.next_serial());
+                        handled = true;
+                    }
+                } else if vertical_amount < 0.0 {
+                    let mouse_pattern = fht_compositor_config::MousePattern(
+                        modifiers,
+                        fht_compositor_config::MouseInput::Axis(fht_compositor_config::MouseAxis::WheelDown),
+                    );
+                    if let Some(action) = self.fht.config.mousebinds.get(&mouse_pattern).cloned() {
+                        self.process_mouse_action(0, action, SERIAL_COUNTER.next_serial());
+                        handled = true;
+                    }
+                }
+                
+                // Check horizontal axis bindings
+                if !handled && horizontal_amount > 0.0 {
+                    let mouse_pattern = fht_compositor_config::MousePattern(
+                        modifiers,
+                        fht_compositor_config::MouseInput::Axis(fht_compositor_config::MouseAxis::WheelRight),
+                    );
+                    if let Some(action) = self.fht.config.mousebinds.get(&mouse_pattern).cloned() {
+                        self.process_mouse_action(0, action, SERIAL_COUNTER.next_serial());
+                        handled = true;
+                    }
+                } else if !handled && horizontal_amount < 0.0 {
+                    let mouse_pattern = fht_compositor_config::MousePattern(
+                        modifiers,
+                        fht_compositor_config::MouseInput::Axis(fht_compositor_config::MouseAxis::WheelLeft),
+                    );
+                    if let Some(action) = self.fht.config.mousebinds.get(&mouse_pattern).cloned() {
+                        self.process_mouse_action(0, action, SERIAL_COUNTER.next_serial());
+                        handled = true;
+                    }
+                }
+
+                // Only forward to pointer if we didn't handle it with a binding
+                if !handled {
                     let mut frame = AxisFrame::new(event.time_msec()).source(event.source());
 
                     if horizontal_amount != 0.0 {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -575,45 +575,51 @@ impl State {
                 let modifiers = self.fht.keyboard.modifier_state().into();
                 let mut handled = false;
                 
-                // Check vertical axis bindings
-                if vertical_amount > 0.0 {
-                    let mouse_pattern = fht_compositor_config::MousePattern(
-                        modifiers,
-                        fht_compositor_config::MouseInput::Axis(fht_compositor_config::MouseAxis::WheelUp),
-                    );
-                    if let Some(action) = self.fht.config.mousebinds.get(&mouse_pattern).cloned() {
-                        self.process_mouse_action(0, action, SERIAL_COUNTER.next_serial());
-                        handled = true;
-                    }
-                } else if vertical_amount < 0.0 {
-                    let mouse_pattern = fht_compositor_config::MousePattern(
-                        modifiers,
-                        fht_compositor_config::MouseInput::Axis(fht_compositor_config::MouseAxis::WheelDown),
-                    );
-                    if let Some(action) = self.fht.config.mousebinds.get(&mouse_pattern).cloned() {
-                        self.process_mouse_action(0, action, SERIAL_COUNTER.next_serial());
-                        handled = true;
+                // Check vertical axis bindings using discrete amounts
+                if let Some(discrete) = vertical_amount_discrete {
+                    if discrete > 0.0 {                    
+                        let mouse_pattern = fht_compositor_config::MousePattern(
+                            modifiers,
+                            fht_compositor_config::MouseInput::Axis(fht_compositor_config::MouseAxis::WheelUp),
+                        );
+                        if let Some(action) = self.fht.config.mousebinds.get(&mouse_pattern).cloned() {
+                            self.process_mouse_action(0, action, SERIAL_COUNTER.next_serial());
+                            handled = true;
+                        }
+                    } else if discrete < 0.0 {
+                        let mouse_pattern = fht_compositor_config::MousePattern(
+                            modifiers,
+                            fht_compositor_config::MouseInput::Axis(fht_compositor_config::MouseAxis::WheelDown),
+                        );
+                        if let Some(action) = self.fht.config.mousebinds.get(&mouse_pattern).cloned() {
+                            self.process_mouse_action(0, action, SERIAL_COUNTER.next_serial());
+                            handled = true;
+                        }
                     }
                 }
-                
-                // Check horizontal axis bindings
-                if !handled && horizontal_amount > 0.0 {
-                    let mouse_pattern = fht_compositor_config::MousePattern(
-                        modifiers,
-                        fht_compositor_config::MouseInput::Axis(fht_compositor_config::MouseAxis::WheelRight),
-                    );
-                    if let Some(action) = self.fht.config.mousebinds.get(&mouse_pattern).cloned() {
-                        self.process_mouse_action(0, action, SERIAL_COUNTER.next_serial());
-                        handled = true;
-                    }
-                } else if !handled && horizontal_amount < 0.0 {
-                    let mouse_pattern = fht_compositor_config::MousePattern(
-                        modifiers,
-                        fht_compositor_config::MouseInput::Axis(fht_compositor_config::MouseAxis::WheelLeft),
-                    );
-                    if let Some(action) = self.fht.config.mousebinds.get(&mouse_pattern).cloned() {
-                        self.process_mouse_action(0, action, SERIAL_COUNTER.next_serial());
-                        handled = true;
+
+                // Check horizontal axis bindings using discrete amounts
+                if !handled {
+                    if let Some(discrete) = horizontal_amount_discrete {
+                        if discrete > 0.0 {
+                            let mouse_pattern = fht_compositor_config::MousePattern(
+                                modifiers,
+                                fht_compositor_config::MouseInput::Axis(fht_compositor_config::MouseAxis::WheelRight),
+                            );
+                            if let Some(action) = self.fht.config.mousebinds.get(&mouse_pattern).cloned() {
+                                self.process_mouse_action(0, action, SERIAL_COUNTER.next_serial());
+                                handled = true;
+                            }
+                        } else if discrete < 0.0 {
+                            let mouse_pattern = fht_compositor_config::MousePattern(
+                                modifiers,
+                                fht_compositor_config::MouseInput::Axis(fht_compositor_config::MouseAxis::WheelLeft),
+                            );
+                            if let Some(action) = self.fht.config.mousebinds.get(&mouse_pattern).cloned() {
+                                self.process_mouse_action(0, action, SERIAL_COUNTER.next_serial());
+                                handled = true;
+                            }
+                        }
                     }
                 }
 

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -4,7 +4,7 @@ pub mod resize_tile_grab;
 pub mod swap_tile_grab;
 
 pub use actions::*;
-use fht_compositor_config::KeyPattern;
+use fht_compositor_config::{KeyPattern};
 use smithay::backend::input::{
     AbsolutePositionEvent, Axis, AxisSource, Device, DeviceCapability, Event, GestureBeginEvent,
     GestureEndEvent, GesturePinchUpdateEvent, GestureSwipeUpdateEvent, InputBackend, InputEvent,

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -4,7 +4,7 @@ pub mod resize_tile_grab;
 pub mod swap_tile_grab;
 
 pub use actions::*;
-use fht_compositor_config::{KeyPattern};
+use fht_compositor_config::KeyPattern;
 use smithay::backend::input::{
     AbsolutePositionEvent, Axis, AxisSource, Device, DeviceCapability, Event, GestureBeginEvent,
     GestureEndEvent, GesturePinchUpdateEvent, GestureSwipeUpdateEvent, InputBackend, InputEvent,


### PR DESCRIPTION
This is a frequent feature for compositors. This way, we can set mousebinds such as super-scroll{up/down} to switch workspaces (for example).

This is very complicated because the Linux kernel doesn't have an actual event key for scroll up and down so we have to make axis events handling.

### Todo:
- [x] Add option handling
- [x] Find the actual event key handling method
- [x] Add the axis handler in the main input mod
- [x] Clean the code

If you have tips, ideas or wanna help to go faster, don't hesitate

**Ready for review, tested and approved**