### PR TITLE
Fix start on FreeBSD

### DIFF
--- a/src/backend/udev.rs
+++ b/src/backend/udev.rs
@@ -274,8 +274,11 @@ impl UdevData {
                 .expect("Please make sure that {user_path} is a render node!");
             let primary_node = primary_gpu
                 .node_with_type(NodeType::Primary)
-                .expect("Unable to get primary node from primary gpu node!")
-                .expect("Unable to get primary node from primary gpu node!");
+                .and_then(Result::ok)
+                .unwrap_or_else(|| {
+                    warn!("Unable to get primary node from primary gpu node! Falling back to primary gpu node.");
+                    primary_gpu
+                });
 
             (primary_gpu, primary_node)
         } else {
@@ -285,8 +288,11 @@ impl UdevData {
                 .expect("Failed to get primary gpu!");
             let primary_gpu = primary_node
                 .node_with_type(NodeType::Render)
-                .expect("Failed to get primary gpu node from primary node!")
-                .expect("Failed to get primary gpu node from primary node!");
+                .and_then(Result::ok)
+                .unwrap_or_else(|| {
+                    warn!("Unable to get primary node from primary gpu node! Falling back to primary gpu node.");
+                    primary_node
+                });
 
             (primary_gpu, primary_node)
         };


### PR DESCRIPTION
Simply return primary gpu node when primary render node not found.

Refer to: https://github.com/YaLTeR/niri/blob/c8eea8ee9ddf795da8cb356599f17e2dc7cfea20/src/backend/tty.rs#L315-L320

<img width="1920" height="1080" alt="20251025_03h59m07s_grim" src="https://github.com/user-attachments/assets/a2b1d251-6e23-47f3-8b07-2a177afa98ce" />
