### PR TITLE
fix offset calculation in start_swipe_gesture

### DIFF
--- a/src/space/monitor.rs
+++ b/src/space/monitor.rs
@@ -269,13 +269,7 @@ impl Monitor {
 
     /// Start a swipe gesture at the monitor level
     pub fn start_swipe_gesture(&mut self, animation_config: &WorkspaceSwitchAnimation) {
-        let previous_offset = if let Some(previous_swipe) = self.swipe_state.take() {
-            previous_swipe.total_offset
-        } else if let Some(current_offset) = self.active_workspace().render_offset() {
-            Point::from((current_offset.x as f64, current_offset.y as f64))
-        } else {
-            Point::from((0.0, 0.0))
-        };
+        let previous_offset = Point::from((0.0, 0.0));
 
         self.swipe_state = Some(MonitorSwipeState {
             direction: None,


### PR DESCRIPTION
I noticed that when you swipe too fast to change workspace, the workspace animation resets when you swipe during the previous animation. 

When starting a new swipe, we should always begin from a zero offset, regardless of any ongoing animations. This prevents the workspace from jumping back to a previous state if a swipe is initiated while another animation is in progress.