### PR TITLE
feat: `hyprland-global-shortcuts-v1` support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1028,6 +1028,7 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "tracy-client",
+ "wayland-scanner",
  "xcursor",
  "xdg",
  "zbus",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ libdisplay-info = "0.3.0"
 drm-ffi = "0.9.0"
 sd-notify = { version = "0.4.5", optional = true }
 futures-util = { version = "0.3.31", features = ["std", "io"] }
+wayland-scanner = "0.31.7"
 [dependencies.pipewire]
 git = "https://gitlab.freedesktop.org/pipewire/pipewire-rs.git"
 rev = "fd3d8f7861a29c2eeaa4c393402e013578bb36d9"

--- a/fht-compositor-config/src/lib.rs
+++ b/fht-compositor-config/src/lib.rs
@@ -269,6 +269,7 @@ pub enum ComplexKeyAction {
     ChangeWindowProportion(f64),
     FocusWorkspace(usize),
     SendToWorkspace(usize),
+    GlobalShortcut(String),
 }
 
 #[derive(Debug, Clone, Copy, Deserialize, PartialEq, Eq, Hash)]

--- a/fht-compositor-ipc/src/lib.rs
+++ b/fht-compositor-ipc/src/lib.rs
@@ -88,6 +88,8 @@ pub enum Request {
     PickLayerShell,
     /// Request the cursor position.
     CursorPosition,
+    /// Request information about all registered global shortcuts.
+    GlobalShortcuts,
     /// Request the compositor to execute an action.
     Action(Action),
     /// Subscribe to the IPC, receiving events continuously.
@@ -118,6 +120,8 @@ pub enum Response {
     PickedLayerShell(PickLayerShellResult),
     /// The cursor position.
     CursorPosition { x: f64, y: f64 },
+    /// All registered global shortcuts.
+    GlobalShortcuts(Vec<GlobalShortcut>),
     /// There was an error handling the request.
     Error(String),
     /// Noop, for requests that do not need a result/output.
@@ -400,6 +404,20 @@ pub enum Layer {
     Bottom,
     Top,
     Overlay,
+}
+
+/// A registered global shortcut from the `hyprland-global-shortcuts-v1` protocol.
+#[derive(Serialize, Deserialize, Debug, Clone, PartialEq, JsonSchema)]
+#[serde(rename_all = "kebab-case", deny_unknown_fields)]
+pub struct GlobalShortcut {
+    /// The application ID that registered this shortcut.
+    pub app_id: String,
+    /// The shortcut identifier.
+    pub id: String,
+    /// A human-readable description of the shortcut.
+    pub description: String,
+    /// A human-readable description of how to trigger the shortcut.
+    pub trigger_description: String,
 }
 
 /// An action to execute. This enum includes all possible key actions found in

--- a/res/protocols/hyprland-global-shortcuts-v1.xml
+++ b/res/protocols/hyprland-global-shortcuts-v1.xml
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="hyprland_global_shortcuts_v1">
+  <copyright>
+    Copyright © 2022 Vaxry
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    1. Redistributions of source code must retain the above copyright notice, this
+       list of conditions and the following disclaimer.
+
+    2. Redistributions in binary form must reproduce the above copyright notice,
+       this list of conditions and the following disclaimer in the documentation
+       and/or other materials provided with the distribution.
+
+    3. Neither the name of the copyright holder nor the names of its
+       contributors may be used to endorse or promote products derived from
+       this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  </copyright>
+
+  <description summary="registering global shortcuts">
+    This protocol allows a client to register triggerable actions,
+    meant to be global shortcuts.
+  </description>
+
+  <interface name="hyprland_global_shortcuts_manager_v1" version="1">
+    <description summary="manager to register global shortcuts">
+      This object is a manager which offers requests to create global shortcuts.
+    </description>
+
+    <request name="register_shortcut">
+      <description summary="register a shortcut">
+        Register a new global shortcut.
+
+        A global shortcut is anonymous, meaning the app does not know what key(s) trigger it.
+
+        The shortcut's keybinding shall be dealt with by the compositor.
+
+        In the case of a duplicate app_id + id combination, the already_taken protocol error is raised.
+      </description>
+      <arg name="shortcut" type="new_id" interface="hyprland_global_shortcut_v1"/>
+      <arg name="id" type="string" summary="a unique id for the shortcut"/>
+      <arg name="app_id" type="string" summary="the app_id of the application requesting the shortcut"/>
+      <arg name="description" type="string" summary="user-readable text describing what the shortcut does."/>
+      <arg name="trigger_description" type="string" summary="user-readable text describing how to trigger the shortcut for the client to render."/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        All objects created by the manager will still remain valid, until their
+        appropriate destroy request has been called.
+      </description>
+    </request>
+
+    <enum name="error">
+      <entry name="already_taken" value="0"
+        summary="the app_id + id combination has already been registered."/>
+    </enum>
+  </interface>
+
+  <interface name="hyprland_global_shortcut_v1" version="1">
+    <description summary="a shortcut">
+      This object represents a single shortcut.
+    </description>
+
+    <event name="pressed">
+      <description summary="keystroke pressed">
+        The keystroke was pressed.
+
+        tv_ values hold the timestamp of the occurrence.
+      </description>
+      <arg name="tv_sec_hi" type="uint"
+           summary="high 32 bits of the seconds part of the timestamp"/>
+      <arg name="tv_sec_lo" type="uint"
+           summary="low 32 bits of the seconds part of the timestamp"/>
+      <arg name="tv_nsec" type="uint"
+           summary="nanoseconds part of the timestamp"/>
+    </event>
+
+    <event name="released">
+      <description summary="keystroke released">
+        The keystroke was released.
+
+        tv_ values hold the timestamp of the occurrence.
+      </description>
+      <arg name="tv_sec_hi" type="uint"
+           summary="high 32 bits of the seconds part of the timestamp"/>
+      <arg name="tv_sec_lo" type="uint"
+           summary="low 32 bits of the seconds part of the timestamp"/>
+      <arg name="tv_nsec" type="uint"
+           summary="nanoseconds part of the timestamp"/>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="delete this object, used or not">
+        Destroys the shortcut. Can be sent at any time by the client.
+      </description>
+    </request>
+  </interface>
+</protocol>

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -88,6 +88,8 @@ pub enum Request {
     PickLayerShell,
     /// Get the cursor position.
     CursorPosition,
+    /// List all registered global shortcuts.
+    GlobalShortcuts,
     /// Request the compositor to execute an action.
     Action {
         #[command(subcommand)]

--- a/src/handlers/hyprland_global_shortcuts.rs
+++ b/src/handlers/hyprland_global_shortcuts.rs
@@ -1,0 +1,26 @@
+use crate::delegate_hyprland_global_shortcuts;
+use crate::protocols::hyprland_global_shortcuts::{
+    HyprlandGlobalShortcutsHandler, HyprlandGlobalShortcutsState, ShortcutData,
+};
+use crate::state::State;
+
+impl HyprlandGlobalShortcutsHandler for State {
+    fn hyprland_global_shortcuts_state(&mut self) -> &mut HyprlandGlobalShortcutsState {
+        &mut self.fht.hyprland_global_shortcuts_state
+    }
+
+    fn new_shortcut(&mut self, data: ShortcutData) {
+        debug!(
+            app_id = %data.app_id,
+            id = %data.id,
+            description = %data.description,
+            "Registered global shortcut"
+        );
+    }
+
+    fn shortcut_destroyed(&mut self, app_id: String, id: String) {
+        debug!(%app_id, %id, "Global shortcut destroyed");
+    }
+}
+
+delegate_hyprland_global_shortcuts!(State);

--- a/src/handlers/mod.rs
+++ b/src/handlers/mod.rs
@@ -16,6 +16,7 @@ mod foreign_toplevel_list;
 mod fractional_scale;
 #[cfg(feature = "udev-backend")]
 pub mod gamma_control;
+mod hyprland_global_shortcuts;
 mod idle_inhibit;
 mod input_method;
 mod keyboard_shortcuts_inhibit;

--- a/src/input/actions.rs
+++ b/src/input/actions.rs
@@ -49,6 +49,10 @@ pub enum KeyActionType {
     FocusNextWorkspace,
     FocusPreviousWorkspace,
     DisableOuptuts,
+    GlobalShortcut {
+        app_id: String,
+        shortcut_id: String,
+    },
     #[default]
     None,
 }
@@ -168,6 +172,19 @@ impl From<fht_compositor_config::KeyActionDesc> for KeyAction {
                     ComplexKeyAction::SendToWorkspace(idx) => {
                         KeyActionType::SendFocusedWindowToWorkspace(idx)
                     }
+                    ComplexKeyAction::GlobalShortcut(arg) => match arg.split_once(':') {
+                        Some((app_id, shortcut_id)) => KeyActionType::GlobalShortcut {
+                            app_id: app_id.to_string(),
+                            shortcut_id: shortcut_id.to_string(),
+                        },
+                        None => {
+                            tracing::warn!(
+                                    ?arg,
+                                    "Invalid global-shortcut arg format, expected '<app_id>:<shortcut_id>'"
+                                );
+                            KeyActionType::None
+                        }
+                    },
                 };
             }
         }
@@ -426,6 +443,10 @@ impl State {
                     mon.workspace_mut_by_index(idx)
                         .insert_window(window, location, true);
                 }
+            }
+            KeyActionType::GlobalShortcut { .. } => {
+                // Handled directly in the keyboard input closure, should never reach here.
+                unreachable!("GlobalShortcut actions are handled in the keyboard input filter");
             }
             KeyActionType::None => (), // disabled the key combo
         }

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -455,13 +455,55 @@ impl State {
                     }
                 }
 
-                handle_key_action(
+                let result = handle_key_action(
                     &state.fht.config.keybinds,
                     &mut state.fht.suppressed_keys,
                     modifiers,
                     key_state,
                     raw,
-                )
+                );
+
+                // For global shortcuts, we handle press/release directly here instead of
+                // going through process_key_action.
+                match &result {
+                    FilterResult::Intercept((_, action)) => {
+                        if let KeyActionType::GlobalShortcut {
+                            app_id,
+                            shortcut_id,
+                        } = &action.r#type
+                        {
+                            // SAFETY: handle_key_action will never intercept if raw.is_none()
+                            let keysym = raw.unwrap();
+                            let shortcuts = &state.fht.hyprland_global_shortcuts_state;
+                            if !shortcuts.has_shortcut(app_id, shortcut_id) {
+                                // No client registered this shortcut, undo the suppression
+                                // and forward the key to the focused client.
+                                state.fht.suppressed_keys.remove(&keysym);
+                                return FilterResult::Forward;
+                            }
+
+                            let time = crate::utils::get_monotonic_time();
+                            match key_state {
+                                KeyState::Pressed => {
+                                    shortcuts.press_shortcut(app_id, shortcut_id, time);
+                                }
+                                KeyState::Released => {
+                                    shortcuts.release_shortcut(app_id, shortcut_id, time);
+                                }
+                            }
+
+                            // Intercept with a no-op so process_key_action doesn't try to
+                            // handle this again.
+                            return FilterResult::Intercept((
+                                KeyPattern::default(),
+                                KeyAction::none(),
+                            ));
+                        }
+                    }
+                    _ => {}
+                }
+
+                result
             },
         );
 

--- a/src/ipc/client.rs
+++ b/src/ipc/client.rs
@@ -26,6 +26,7 @@ pub fn make_request(request: cli::Request, json: bool) -> anyhow::Result<()> {
         cli::Request::PickWindow => fht_compositor_ipc::Request::PickWindow,
         cli::Request::Action { action } => fht_compositor_ipc::Request::Action(action),
         cli::Request::CursorPosition => fht_compositor_ipc::Request::CursorPosition,
+        cli::Request::GlobalShortcuts => fht_compositor_ipc::Request::GlobalShortcuts,
         cli::Request::PrintSchema => return fht_compositor_ipc::print_schema(),
         cli::Request::Subscribe => {
             subscribe = true;
@@ -115,6 +116,9 @@ pub fn make_request(request: cli::Request, json: bool) -> anyhow::Result<()> {
             },
             fht_compositor_ipc::Response::CursorPosition { x, y } => {
                 Ok(serde_json::json!({ "x": x, "y": y }).to_string())
+            }
+            fht_compositor_ipc::Response::GlobalShortcuts(shortcuts) => {
+                serde_json::to_string(&shortcuts)
             }
             fht_compositor_ipc::Response::Noop => return Ok(()),
         }?;
@@ -268,6 +272,24 @@ fn print_formatted(res: &fht_compositor_ipc::Response) -> anyhow::Result<()> {
         },
         fht_compositor_ipc::Response::CursorPosition { x, y } => {
             writeln!(&mut writer, "Cursor position: {x}, {y}")?;
+        }
+        fht_compositor_ipc::Response::GlobalShortcuts(shortcuts) => {
+            if shortcuts.is_empty() {
+                writeln!(&mut writer, "No global shortcuts registered.")?;
+            } else {
+                for (idx, shortcut) in shortcuts.iter().enumerate() {
+                    writeln!(&mut writer, "Global Shortcut #{idx}:")?;
+                    writeln!(&mut writer, "\tApp ID: {}", shortcut.app_id)?;
+                    writeln!(&mut writer, "\tID: {}", shortcut.id)?;
+                    writeln!(&mut writer, "\tDescription: {}", shortcut.description)?;
+                    writeln!(
+                        &mut writer,
+                        "\tTrigger Description: {}",
+                        shortcut.trigger_description
+                    )?;
+                    writeln!(&mut writer, "---")?;
+                }
+            }
         }
         fht_compositor_ipc::Response::Error(err) => anyhow::bail!(err.clone()),
         fht_compositor_ipc::Response::Noop => (),

--- a/src/ipc/mod.rs
+++ b/src/ipc/mod.rs
@@ -246,6 +246,7 @@ enum ClientRequest {
     PickWindow(async_channel::Sender<fht_compositor_ipc::PickWindowResult>),
     PickLayerShell(async_channel::Sender<fht_compositor_ipc::PickLayerShellResult>),
     CursorPosition(async_channel::Sender<(f64, f64)>),
+    GlobalShortcuts(async_channel::Sender<Vec<fht_compositor_ipc::GlobalShortcut>>),
     Action(
         fht_compositor_ipc::Action,
         async_channel::Sender<anyhow::Result<()>>,
@@ -359,6 +360,17 @@ async fn handle_request(
             let (x, y) = rx.recv().await.context("Failed to receive action result")?;
             Ok(Response::CursorPosition { x, y })
         }
+        fht_compositor_ipc::Request::GlobalShortcuts => {
+            let (tx, rx) = async_channel::bounded(1);
+            to_compositor
+                .send(ClientRequest::GlobalShortcuts(tx))
+                .context("IPC communication channel closed")?;
+            let shortcuts = rx
+                .recv()
+                .await
+                .context("Failed to receive global shortcuts")?;
+            Ok(Response::GlobalShortcuts(shortcuts))
+        }
         fht_compositor_ipc::Request::Action(action) => {
             let (tx, rx) = async_channel::bounded(1);
             to_compositor
@@ -465,6 +477,21 @@ impl State {
             }
             ClientRequest::CursorPosition(tx) => {
                 tx.send_blocking(self.fht.pointer.current_location().into())?;
+            }
+            ClientRequest::GlobalShortcuts(tx) => {
+                let shortcuts = self
+                    .fht
+                    .hyprland_global_shortcuts_state
+                    .list_shortcuts()
+                    .into_iter()
+                    .map(|data| fht_compositor_ipc::GlobalShortcut {
+                        app_id: data.app_id.clone(),
+                        id: data.id.clone(),
+                        description: data.description.clone(),
+                        trigger_description: data.trigger_description.clone(),
+                    })
+                    .collect();
+                tx.send_blocking(shortcuts)?;
             }
             ClientRequest::Action(action, tx) => {
                 tx.send_blocking(self.handle_ipc_action(action))?;

--- a/src/protocols/hyprland_global_shortcuts.rs
+++ b/src/protocols/hyprland_global_shortcuts.rs
@@ -73,6 +73,15 @@ impl HyprlandGlobalShortcutsState {
         self.get(app_id, id).map_or(false, |s| s.is_alive())
     }
 
+    /// Returns the metadata of all currently registered and alive shortcuts.
+    pub fn list_shortcuts(&self) -> Vec<&ShortcutData> {
+        self.shortcuts
+            .values()
+            .filter(|s| s.is_alive())
+            .filter_map(|s| s.data::<ShortcutData>())
+            .collect()
+    }
+
     /// Fire a `pressed` event on the shortcut identified by `(app_id, id)`.
     ///
     /// Returns `true` if the shortcut existed and the event was sent, `false` otherwise.

--- a/src/protocols/hyprland_global_shortcuts.rs
+++ b/src/protocols/hyprland_global_shortcuts.rs
@@ -1,0 +1,236 @@
+//! `hyprland-global-shortcuts-v1` protocol support.
+//!
+//! This protocol is from Hyprland and is mostly implemented to help Sleex transition into being
+//! used in `fht-compositor`. Shortcuts can only be triggered if they are explicitly configured.
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use smithay::reexports::wayland_server::{
+    Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, Resource,
+};
+
+use crate::protocols::raw::hyprland_global_shortcuts_v1::hyprland_global_shortcut_v1::HyprlandGlobalShortcutV1;
+use crate::protocols::raw::hyprland_global_shortcuts_v1::hyprland_global_shortcuts_manager_v1::{
+    self, HyprlandGlobalShortcutsManagerV1,
+};
+use crate::state::State;
+use crate::utils::split_timestamp;
+
+const VERSION: u32 = 1;
+
+pub struct HyprlandGlobalShortcutsManagerGlobalData {
+    filter: Box<dyn Fn(&Client) -> bool + Send + Sync>,
+}
+
+/// Metadata attached to every `hyprland_global_shortcut_v1` resource.
+#[derive(Debug, Clone)]
+pub struct ShortcutData {
+    pub app_id: String,
+    pub id: String,
+    pub description: String,
+    pub trigger_description: String,
+}
+
+pub struct HyprlandGlobalShortcutsState {
+    /// Live shortcut resources keyed by `(app_id, id)`.
+    shortcuts: HashMap<(String, String), HyprlandGlobalShortcutV1>,
+}
+
+impl std::fmt::Debug for HyprlandGlobalShortcutsState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("HyprlandGlobalShortcutsState")
+            .field("shortcuts_count", &self.shortcuts.len())
+            .finish()
+    }
+}
+
+impl HyprlandGlobalShortcutsState {
+    /// Create the global and return a new state object.
+    ///
+    /// `filter` controls which clients may bind the global (e.g. restrict to trusted clients).
+    pub fn new<F>(display: &DisplayHandle, filter: F) -> Self
+    where
+        F: Fn(&Client) -> bool + Send + Sync + 'static,
+    {
+        let global_data = HyprlandGlobalShortcutsManagerGlobalData {
+            filter: Box::new(filter),
+        };
+        display.create_global::<State, HyprlandGlobalShortcutsManagerV1, _>(VERSION, global_data);
+        Self {
+            shortcuts: HashMap::new(),
+        }
+    }
+
+    /// Look up a registered shortcut by its `(app_id, id)` key.
+    fn get(&self, app_id: &str, id: &str) -> Option<&HyprlandGlobalShortcutV1> {
+        self.shortcuts.get(&(app_id.to_owned(), id.to_owned()))
+    }
+
+    /// Fire a `pressed` event on the shortcut identified by `(app_id, id)`.
+    ///
+    /// Returns `true` if the shortcut existed and the event was sent, `false` otherwise.
+    pub fn press_shortcut(&self, app_id: &str, id: &str, time: Duration) -> bool {
+        if let Some(shortcut) = self.get(app_id, id) {
+            if shortcut.is_alive() {
+                let (tv_sec_hi, tv_sec_lo, tv_nsec) = split_timestamp(time);
+                shortcut.pressed(tv_sec_hi, tv_sec_lo, tv_nsec);
+                return true;
+            }
+        }
+        false
+    }
+
+    /// Fire a `released` event on the shortcut identified by `(app_id, id)`.
+    ///
+    /// Returns `true` if the shortcut existed and the event was sent, `false` otherwise.
+    pub fn release_shortcut(&self, app_id: &str, id: &str, time: Duration) -> bool {
+        if let Some(shortcut) = self.get(app_id, id) {
+            if shortcut.is_alive() {
+                let (tv_sec_hi, tv_sec_lo, tv_nsec) = split_timestamp(time);
+                shortcut.released(tv_sec_hi, tv_sec_lo, tv_nsec);
+                return true;
+            }
+        }
+        false
+    }
+}
+
+pub trait HyprlandGlobalShortcutsHandler {
+    fn hyprland_global_shortcuts_state(&mut self) -> &mut HyprlandGlobalShortcutsState;
+    fn new_shortcut(&mut self, data: ShortcutData);
+    fn shortcut_destroyed(&mut self, app_id: String, id: String);
+}
+
+impl
+    GlobalDispatch<
+        HyprlandGlobalShortcutsManagerV1,
+        HyprlandGlobalShortcutsManagerGlobalData,
+        State,
+    > for HyprlandGlobalShortcutsState
+{
+    fn bind(
+        _state: &mut State,
+        _handle: &DisplayHandle,
+        _client: &Client,
+        resource: smithay::reexports::wayland_server::New<HyprlandGlobalShortcutsManagerV1>,
+        _global_data: &HyprlandGlobalShortcutsManagerGlobalData,
+        data_init: &mut DataInit<'_, State>,
+    ) {
+        data_init.init(resource, ());
+    }
+
+    fn can_view(client: Client, global_data: &HyprlandGlobalShortcutsManagerGlobalData) -> bool {
+        (global_data.filter)(&client)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch — manager requests
+// ---------------------------------------------------------------------------
+
+impl Dispatch<HyprlandGlobalShortcutsManagerV1, (), State> for HyprlandGlobalShortcutsState {
+    fn request(
+        state: &mut State,
+        _client: &Client,
+        manager: &HyprlandGlobalShortcutsManagerV1,
+        request: hyprland_global_shortcuts_manager_v1::Request,
+        _data: &(),
+        _dhandle: &DisplayHandle,
+        data_init: &mut DataInit<'_, State>,
+    ) {
+        match request {
+            hyprland_global_shortcuts_manager_v1::Request::RegisterShortcut {
+                shortcut,
+                id,
+                app_id,
+                description,
+                trigger_description,
+            } => {
+                let key = (app_id.clone(), id.clone());
+
+                // Check for duplicates — the protocol requires an already_taken error.
+                let handler_state = state.hyprland_global_shortcuts_state();
+                if handler_state.shortcuts.contains_key(&key) {
+                    manager.post_error(
+                        hyprland_global_shortcuts_manager_v1::Error::AlreadyTaken,
+                        format!("This '{app_id}:{id}' shortcut has already been registered"),
+                    );
+                    return;
+                }
+
+                let shortcut_data = ShortcutData {
+                    app_id: app_id.clone(),
+                    id: id.clone(),
+                    description: description.clone(),
+                    trigger_description: trigger_description.clone(),
+                };
+
+                let resource = data_init.init(shortcut, shortcut_data.clone());
+                state
+                    .hyprland_global_shortcuts_state()
+                    .shortcuts
+                    .insert(key, resource);
+
+                state.new_shortcut(shortcut_data);
+            }
+            hyprland_global_shortcuts_manager_v1::Request::Destroy => {
+                // Manager object destroyed — individual shortcuts remain valid until they are
+                // explicitly destroyed, as per the protocol spec.
+            }
+            #[allow(unreachable_patterns)]
+            _ => unreachable!(),
+        }
+    }
+}
+
+impl Dispatch<HyprlandGlobalShortcutV1, ShortcutData, State> for HyprlandGlobalShortcutsState {
+    fn request(
+        state: &mut State,
+        _client: &Client,
+        _resource: &HyprlandGlobalShortcutV1,
+        request: <HyprlandGlobalShortcutV1 as Resource>::Request,
+        data: &ShortcutData,
+        _dhandle: &DisplayHandle,
+        _data_init: &mut DataInit<'_, State>,
+    ) {
+        use crate::protocols::raw::hyprland_global_shortcuts_v1::hyprland_global_shortcut_v1::Request;
+        match request {
+            Request::Destroy => {
+                let key = (data.app_id.clone(), data.id.clone());
+                state
+                    .hyprland_global_shortcuts_state()
+                    .shortcuts
+                    .remove(&key);
+                state.shortcut_destroyed(data.app_id.clone(), data.id.clone());
+            }
+            #[allow(unreachable_patterns)]
+            _ => unreachable!(),
+        }
+    }
+}
+
+#[macro_export]
+macro_rules! delegate_hyprland_global_shortcuts {
+    ($(@<$( $lt:tt $( : $clt:tt $(+ $dlt:tt )* )? ),+>)? $ty:ty) => {
+        smithay::reexports::wayland_server::delegate_global_dispatch!(
+            $(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+                $crate::protocols::raw::hyprland_global_shortcuts_v1::hyprland_global_shortcuts_manager_v1::HyprlandGlobalShortcutsManagerV1:
+                    $crate::protocols::hyprland_global_shortcuts::HyprlandGlobalShortcutsManagerGlobalData
+            ] => $crate::protocols::hyprland_global_shortcuts::HyprlandGlobalShortcutsState
+        );
+
+        smithay::reexports::wayland_server::delegate_dispatch!(
+            $(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+                $crate::protocols::raw::hyprland_global_shortcuts_v1::hyprland_global_shortcuts_manager_v1::HyprlandGlobalShortcutsManagerV1: ()
+            ] => $crate::protocols::hyprland_global_shortcuts::HyprlandGlobalShortcutsState
+        );
+
+        smithay::reexports::wayland_server::delegate_dispatch!(
+            $(@< $( $lt $( : $clt $(+ $dlt )* )? ),+ >)? $ty: [
+                $crate::protocols::raw::hyprland_global_shortcuts_v1::hyprland_global_shortcut_v1::HyprlandGlobalShortcutV1:
+                    $crate::protocols::hyprland_global_shortcuts::ShortcutData
+            ] => $crate::protocols::hyprland_global_shortcuts::HyprlandGlobalShortcutsState
+        );
+    };
+}

--- a/src/protocols/hyprland_global_shortcuts.rs
+++ b/src/protocols/hyprland_global_shortcuts.rs
@@ -6,6 +6,7 @@
 use std::collections::HashMap;
 use std::time::Duration;
 
+use smithay::reexports::wayland_server::backend::ClientId;
 use smithay::reexports::wayland_server::{
     Client, DataInit, Dispatch, DisplayHandle, GlobalDispatch, Resource,
 };
@@ -222,6 +223,20 @@ impl Dispatch<HyprlandGlobalShortcutV1, ShortcutData, State> for HyprlandGlobalS
             #[allow(unreachable_patterns)]
             _ => unreachable!(),
         }
+    }
+
+    fn destroyed(
+        state: &mut State,
+        _client: ClientId,
+        _resource: &HyprlandGlobalShortcutV1,
+        data: &ShortcutData,
+    ) {
+        let key = (data.app_id.clone(), data.id.clone());
+        state
+            .hyprland_global_shortcuts_state()
+            .shortcuts
+            .remove(&key);
+        state.shortcut_destroyed(data.app_id.clone(), data.id.clone());
     }
 }
 

--- a/src/protocols/hyprland_global_shortcuts.rs
+++ b/src/protocols/hyprland_global_shortcuts.rs
@@ -67,6 +67,12 @@ impl HyprlandGlobalShortcutsState {
         self.shortcuts.get(&(app_id.to_owned(), id.to_owned()))
     }
 
+    /// Returns `true` if a shortcut identified by `(app_id, id)` is currently registered and
+    /// alive.
+    pub fn has_shortcut(&self, app_id: &str, id: &str) -> bool {
+        self.get(app_id, id).map_or(false, |s| s.is_alive())
+    }
+
     /// Fire a `pressed` event on the shortcut identified by `(app_id, id)`.
     ///
     /// Returns `true` if the shortcut existed and the event was sent, `false` otherwise.

--- a/src/protocols/mod.rs
+++ b/src/protocols/mod.rs
@@ -1,3 +1,5 @@
 pub mod ext_workspace;
+pub mod hyprland_global_shortcuts;
 pub mod output_management;
+pub mod raw;
 pub mod screencopy;

--- a/src/protocols/raw.rs
+++ b/src/protocols/raw.rs
@@ -1,0 +1,12 @@
+pub mod hyprland_global_shortcuts_v1 {
+    use smithay::reexports::wayland_server;
+
+    pub mod __interfaces {
+        use smithay::reexports::wayland_server::backend as wayland_backend;
+        wayland_scanner::generate_interfaces!("res/protocols/hyprland-global-shortcuts-v1.xml");
+    }
+
+    use self::__interfaces::*;
+
+    wayland_scanner::generate_server_code!("res/protocols/hyprland-global-shortcuts-v1.xml");
+}

--- a/src/state.rs
+++ b/src/state.rs
@@ -79,6 +79,7 @@ use crate::portals::screencast::{
     self, CursorMode, ScreencastSession, ScreencastSource, StreamMetadata,
 };
 use crate::protocols::ext_workspace::{self, ExtWorkspaceManagerState};
+use crate::protocols::hyprland_global_shortcuts::HyprlandGlobalShortcutsState;
 use crate::protocols::output_management::{self, OutputManagementManagerState};
 use crate::protocols::screencopy::ScreencopyManagerState;
 use crate::renderer::blur::EffectsFramebuffers;
@@ -850,6 +851,7 @@ pub struct Fht {
     pub xdg_shell_state: XdgShellState,
     pub xdg_foreign_state: XdgForeignState,
     pub ext_workspace_manager_state: ExtWorkspaceManagerState,
+    pub hyprland_global_shortcuts_state: HyprlandGlobalShortcutsState,
 }
 
 impl Fht {
@@ -913,6 +915,13 @@ impl Fht {
                 .get_data::<ClientState>()
                 .is_none_or(|data| data.security_context.is_none())
         });
+        let hyprland_global_shortcuts_state =
+            HyprlandGlobalShortcutsState::new(dh, |client| {
+                // Only allow clients that aren't running inside a SC
+                client
+                    .get_data::<ClientState>()
+                    .is_none_or(|data| data.security_context.is_none())
+            });
         ContentTypeState::new::<State>(dh);
         CursorShapeManagerState::new::<State>(dh);
         TextInputManagerState::new::<State>(dh);
@@ -1057,6 +1066,7 @@ impl Fht {
             xdg_shell_state,
             xdg_foreign_state,
             ext_workspace_manager_state,
+            hyprland_global_shortcuts_state,
         }
     }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -92,6 +92,17 @@ pub fn spawn(cmdline: impl Into<OsString>, xdg_activation_token: Option<XdgActiv
     spawn_args(command, xdg_activation_token);
 }
 
+/// Split a [`Duration`] into the three timestamp fields the protocol uses.
+///
+/// Returns `(tv_sec_hi, tv_sec_lo, tv_nsec)`.
+pub fn split_timestamp(time: Duration) -> (u32, u32, u32) {
+    let secs = time.as_secs();
+    let tv_sec_hi = (secs >> 32) as u32;
+    let tv_sec_lo = (secs & 0xFFFF_FFFF) as u32;
+    let tv_nsec = time.subsec_nanos();
+    (tv_sec_hi, tv_sec_lo, tv_nsec)
+}
+
 pub fn get_credentials_for_surface(surface: &WlSurface) -> Option<Credentials> {
     let handle = surface.handle().upgrade()?;
     let dh = DisplayHandle::from(handle);


### PR DESCRIPTION
This pull requests adds support for Hyprland's Global Shortcut model, which is powered by a custom Wayland protocol from the Hypr ecosystem. This protocol is primarily used by [Quickshell](https://quickshell.org), for the [`GlobalShortcut`](https://quickshell.org/docs/v0.1.0/types/Quickshell.Hyprland/GlobalShortcut/) type.

cc: @LeVraiArdox for testing with Sleex