### PR TITLE
fix: revert to space padding instead of null padding

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ docs/.vitepress/dist
 
 # For local testing
 compositor.toml
+mise.toml

--- a/src/backend/udev/mode.rs
+++ b/src/backend/udev/mode.rs
@@ -124,7 +124,7 @@ pub fn get_custom_mode(
 
     let name = {
         let bytes = format!("{width}x{height}@{}", refresh.unwrap_or(60.0)).into_bytes();
-        let mut name = [0u8; 32];
+        let mut name = [b' '; 32];
         for (i, &b) in bytes.iter().take(32).enumerate() {
             name[i] = b;
         }


### PR DESCRIPTION
previous pull request used null padding because i believed that was what DRM used but previous unsafe code used space padding, this pr keeps the space padding and the memory safe code