### PR TITLE
fix type error in udev/mode.rs

### DIFF
--- a/src/backend/udev/mode.rs
+++ b/src/backend/udev/mode.rs
@@ -124,7 +124,7 @@ pub fn get_custom_mode(
 
     let name = {
         let bytes = format!("{width}x{height}@{}", refresh.unwrap_or(60.0)).into_bytes();
-        let mut name = [0u8 as i8; 32];
+        let mut name = [0i8; 32];
         for (i, &b) in bytes.iter().take(32).enumerate() {
             name[i] = b as i8;
         }

--- a/src/backend/udev/mode.rs
+++ b/src/backend/udev/mode.rs
@@ -124,9 +124,9 @@ pub fn get_custom_mode(
 
     let name = {
         let bytes = format!("{width}x{height}@{}", refresh.unwrap_or(60.0)).into_bytes();
-        let mut name = [0u8; 32];
+        let mut name = [0u8 as i8; 32];
         for (i, &b) in bytes.iter().take(32).enumerate() {
-            name[i] = b;
+            name[i] = b as i8;
         }
         name
     };


### PR DESCRIPTION
One previous PR created a type error in backend/udev/mode. `name` should be returned as `[i8; 32]` but is returned as `[u8; 32]`. This fixes this error.