### PR TITLE
Fix: Release keyboard focus from OnDemand layer shells on outside click

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -528,6 +528,8 @@ impl State {
                 if matches!(layer.layer(), Layer::Top | Layer::Overlay) {
                     self.fht.set_on_demand_layer_shell_focus(Some(&layer));
                 }
+            } else {
+                self.fht.set_on_demand_layer_shell_focus(None);
             }
 
             if let Some(window) = focus.as_ref().and_then(|focus| focus.window.as_ref()) {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -529,7 +529,12 @@ impl State {
                     self.fht.set_on_demand_layer_shell_focus(Some(&layer));
                 }
             } else {
-                self.fht.set_on_demand_layer_shell_focus(None);
+                if focus.is_none() {
+                    self.fht.set_on_demand_layer_shell_focus(None);
+                    
+                    let keyboard = self.fht.seat.get_keyboard().unwrap();
+                    keyboard.set_focus(self, None, serial); 
+                }
             }
 
             if let Some(window) = focus.as_ref().and_then(|focus| focus.window.as_ref()) {

--- a/src/state.rs
+++ b/src/state.rs
@@ -1442,7 +1442,7 @@ impl Fht {
 
         // A layer-shell with keyboard interacitivty set to something else got clicked,
         // remove the select one if any
-        if layer.is_some() {
+        if self.focused_on_demand_layer_shell.is_some() {
             self.focused_on_demand_layer_shell = None;
             self.queue_redraw_all();
         }


### PR DESCRIPTION
This fixes a focus trapping bug where clicking outside an `OnDemand` layer shell (e.g., a panel or app launcher) failed to release the keyboard focus. This resulted in the keyboard being "locked" to the shell, making it impossible to type in regular windows after interacting with the UI.