### PR TITLE
Fix release events

### DIFF
--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -528,6 +528,8 @@ impl State {
                 if matches!(layer.layer(), Layer::Top | Layer::Overlay) {
                     self.fht.set_on_demand_layer_shell_focus(Some(&layer));
                 }
+            } else {
+                self.fht.set_on_demand_layer_shell_focus(None);
             }
 
             if let Some(window) = focus.as_ref().and_then(|focus| focus.window.as_ref()) {

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -302,8 +302,6 @@ impl State {
                             let keysym = raw.unwrap();
                             let shortcuts = &state.fht.hyprland_global_shortcuts_state;
                             if !shortcuts.has_shortcut(app_id, shortcut_id) {
-                                // No client registered this shortcut, undo the suppression
-                                // and forward the key to the focused client.
                                 state.fht.suppressed_keys.remove(&keysym);
                                 return FilterResult::Forward;
                             }
@@ -318,8 +316,11 @@ impl State {
                                 }
                             }
 
-                            // Intercept with a no-op so process_key_action doesn't try to
-                            // handle this again.
+                            return FilterResult::Intercept((
+                                KeyPattern::default(),
+                                KeyAction::none(),
+                            ));
+                        } else if key_state == KeyState::Released {
                             return FilterResult::Intercept((
                                 KeyPattern::default(),
                                 KeyAction::none(),

--- a/src/input/mod.rs
+++ b/src/input/mod.rs
@@ -3,7 +3,7 @@ pub mod pick_surface_grab;
 pub mod resize_tile_grab;
 pub mod swap_tile_grab;
 
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::time::Duration;
 
 pub use actions::*;
@@ -259,7 +259,7 @@ impl State {
 
                 // We handled a virtual terminal switch, no need to handle other keybinds.
                 if handle_vt_switch(&mut state.backend, key_state, modified) {
-                    state.fht.suppressed_keys.insert(modified);
+                    state.fht.suppressed_keys.insert(modified, KeyAction::none());
                     return FilterResult::Intercept((KeyPattern::default(), KeyAction::none()));
                 }
 
@@ -1108,7 +1108,7 @@ fn handle_vt_switch(backend: &mut Backend, key_state: KeyState, modified: Keysym
 
 fn handle_key_action(
     keybinds: &HashMap<KeyPattern, fht_compositor_config::KeyActionDesc>,
-    suppressed: &mut HashSet<Keysym>,
+    suppressed: &mut HashMap<Keysym, KeyAction>,
     modifiers: &ModifiersState,
     key_state: KeyState,
     keysym: Option<Keysym>,
@@ -1121,7 +1121,7 @@ fn handle_key_action(
     let key_action = find_keyaction(keybinds, modifiers, keysym);
     if key_state == KeyState::Pressed {
         if let Some(res) = key_action {
-            suppressed.insert(keysym);
+            suppressed.insert(keysym, res.1.clone());
             return FilterResult::Intercept(res);
         } else {
             // There's nothing matching here, we can forward to the client.
@@ -1134,9 +1134,8 @@ fn handle_key_action(
 
     // In this case, we are releasing the key, check if there wasn't a previous keybind, since we
     // should inhibit both the key down and key up event.
-    if suppressed.remove(&keysym) {
-        let key_pattern = key_action.map_or_else(Default::default, |(kp, _)| kp);
-        return FilterResult::Intercept((key_pattern, KeyAction::none()));
+    if let Some(action) = suppressed.remove(&keysym) {
+        return FilterResult::Intercept((KeyPattern::default(), action));
     }
 
     FilterResult::Forward

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,5 +1,5 @@
 use std::cell::RefCell;
-use std::collections::{HashMap, HashSet};
+use std::collections::HashMap;
 use std::sync::Mutex;
 use std::time::{Duration, Instant};
 
@@ -70,6 +70,7 @@ use crate::config::ui as config_ui;
 use crate::cursor::CursorThemeManager;
 use crate::frame_clock::FrameClock;
 use crate::handlers::session_lock::LockState;
+use crate::input::KeyAction;
 use crate::layer::MappedLayer;
 use crate::output::{self, OutputExt, RedrawState};
 #[cfg(feature = "xdg-screencast-portal")]
@@ -764,7 +765,7 @@ pub struct Fht {
     pub keyboard: KeyboardHandle<State>,
     pub pointer: PointerHandle<State>,
     pub clock: Clock<Monotonic>,
-    pub suppressed_keys: HashSet<Keysym>,
+    pub suppressed_keys: HashMap<Keysym, KeyAction>,
     // We store both the timer and the keysym used to trigger the key action.
     // When we remove the keysym from suppressed keys we stop it.
     pub repeated_keyaction_timer: Option<(RegistrationToken, Keysym)>,
@@ -1001,7 +1002,7 @@ impl Fht {
             stop: false,
 
             clock,
-            suppressed_keys: HashSet::new(),
+            suppressed_keys: HashMap::new(),
             repeated_keyaction_timer: None,
             seat,
             devices: vec![],

--- a/src/state.rs
+++ b/src/state.rs
@@ -1442,7 +1442,7 @@ impl Fht {
 
         // A layer-shell with keyboard interacitivty set to something else got clicked,
         // remove the select one if any
-        if layer.is_some() {
+        if self.focused_on_demand_layer_shell.is_some() {
             self.focused_on_demand_layer_shell = None;
             self.queue_redraw_all();
         }


### PR DESCRIPTION
This fixes a "stuck modifier" bug (like a permanently locked Shift key) when using global shortcuts. 

Previously, when a suppressed key was released, the input handler returned `KeyAction::none()`. This caused the compositor to completely swallow the release event, leaving the shell thinking the key was held down forever.