### PR TITLE
nix: fix build failures on unstable nixpkgs due to the incorrect libdisplay-info version

### DIFF
--- a/default.nix
+++ b/default.nix
@@ -2,6 +2,7 @@
   lib,
   libGL,
   libdisplay-info,
+  libdisplay-info_0_3 ? null,
   libinput,
   seatd,
   libxkbcommon,
@@ -55,7 +56,22 @@ rustPlatform.buildRustPackage {
 
   nativeBuildInputs = [rustPlatform.bindgenHook pkg-config installShellFiles];
   buildInputs =
-    [libGL libdisplay-info libinput seatd libxkbcommon mesa libgbm wayland]
+    [
+      (
+        # If libdisplay-info_0_3 is null then that means this an older nixpkgs
+        # is being used where libdisplay-info is still on version 0.3 anyways
+        if builtins.isNull libdisplay-info_0_3
+        then libdisplay-info
+        else libdisplay-info_0_3
+      )
+      libGL
+      libinput
+      seatd
+      libxkbcommon
+      mesa
+      libgbm
+      wayland
+    ]
     ++ lib.optional withXdgScreenCast dbus
     ++ lib.optional withXdgScreenCast pipewire;
 

--- a/fht-share-picker/default.nix
+++ b/fht-share-picker/default.nix
@@ -13,6 +13,7 @@
   pipewire,
   dbus,
   libdisplay-info,
+  libdisplay-info_0_3 ? null,
   libinput,
   pkg-config,
   rustPlatform,
@@ -33,7 +34,25 @@ rustPlatform.buildRustPackage {
   strictDeps = true;
   # NOTE: We need glib in nativeBuildInputs for glib-compile-resources
   nativeBuildInputs = [rustPlatform.bindgenHook pkg-config glib];
-  buildInputs = [glib gtk4 libadwaita libxkbcommon udev seatd dbus libgbm pipewire libdisplay-info libinput];
+  buildInputs = [
+    (
+      # See /default.nix
+      if builtins.isNull libdisplay-info_0_3
+      then libdisplay-info
+      else libdisplay-info_0_3
+    )
+    glib
+    gtk4
+    libadwaita
+    libxkbcommon
+    udev
+    seatd
+    dbus
+    libgbm
+    pipewire
+    libdisplay-info
+    libinput
+  ];
 
   meta = {
     homepage = "https://github.com/nferht/fht-share-picker";

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1781153468,
-        "narHash": "sha256-ZBRmjFtJn/XmHBV230OSabKQqxOoOJunJmBtSt1sLs0=",
-        "owner": "NixOS",
+        "lastModified": 1786384358,
+        "narHash": "sha256-RzPPiWeUtuvymnpuEWsdtzli5w4kjZs49FqEs3/1u+I=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "cd265fd6b43f2ec1257c2e400f648895d2ad7ccd",
+        "rev": "2fcb964de67fcf60b43471c55d5d99e61a9ccb5a",
         "type": "github"
       },
       "original": {


### PR DESCRIPTION
Fixes #150

This abuses pkgs.callPackage by asking for libdisplay-info_0_3 in the parameters, but setting it to null if it isn't present. If it is null then libdisplay-info is used since this means its already version 0.3, if it is present then we use it instead since that menas libdisplay-info is version 0.4.